### PR TITLE
WIP: Markdown support using pulldown-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -345,6 +345,7 @@ dependencies = [
  "jsonrpc-core 14.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-types 0.73.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ropey 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,7 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -473,6 +474,16 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,7 +595,7 @@ version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -864,6 +875,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +927,11 @@ dependencies = [
 [[package]]
 name = "vec_map"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -992,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lsp-types 0.73.0 (registry+https://github.com/rust-lang/crates.io-index)" = "93d0cf64ea141b43d9e055f6b9df13f0bce32b103d84237509ce0a571ab9b159"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c81ffc11c212fa327657cb19dd85eb7419e163b5b076bede2bdb5c974c07e4"
@@ -1000,6 +1024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum pulldown-cmark 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e142c3b8f49d2200605ee6ba0b1d757310e9e7a72afe78c36ee2ef67300ee00"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1045,6 +1070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum trackable 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "11475c3c53b075360eac9794965822cb053996046545f91cf61d90e00b72efa5"
 "checksum trackable_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0f4062d54dd240bde289717d6b4af18048c3dd552f01a0fd93824f5fc4d2d084"
+"checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
@@ -1052,6 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum whoami 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a08eb844b158ea881e81b94556eede7f7e306e4c7b976aad88f49e6e36dec391"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ sloggers = "0.3.5"
 toml = "0.5.6"
 url = { version = "2.1.1", features = ["serde"] }
 whoami = "0.8.1"
+pulldown-cmark = { version = "0.7.1", default_features = false }
 
 [profile.release]
 lto = true

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -821,8 +821,8 @@ define-command -hidden lsp-show-hover -params 3 -docstring %{
     content=$(printf %s "$content" | sed s/\'/\'\'/g)
 
     case $kak_opt_lsp_hover_anchor in
-        true) printf "info -anchor %%arg{1} '%s'" "$content";;
-        *)    printf "info '%s'" "$content";;
+        true) printf "info -markup -anchor %%arg{1} '%s'" "$content";;
+        *)    printf "info -markup '%s'" "$content";;
     esac
 }}
 

--- a/src/general.rs
+++ b/src/general.rs
@@ -37,7 +37,10 @@ pub fn initialize(
             text_document: Some(TextDocumentClientCapabilities {
                 completion: Some(CompletionCapability {
                     completion_item: Some(CompletionItemCapability {
-                        documentation_format: Some(vec![MarkupKind::PlainText]),
+                        documentation_format: Some(vec![
+                            MarkupKind::Markdown,
+                            MarkupKind::PlainText,
+                        ]),
                         snippet_support: Some(ctx.config.snippet_support),
                         ..CompletionItemCapability::default()
                     }),
@@ -63,7 +66,7 @@ pub fn initialize(
                     ..CodeActionCapability::default()
                 }),
                 hover: Some(HoverCapability {
-                    content_format: Some(vec![MarkupKind::PlainText]),
+                    content_format: Some(vec![MarkupKind::Markdown, MarkupKind::PlainText]),
                     ..HoverCapability::default()
                 }),
                 semantic_highlighting_capabilities: Some(SemanticHighlightingClientCapability {
@@ -71,7 +74,10 @@ pub fn initialize(
                 }),
                 signature_help: Some(SignatureHelpCapability {
                     signature_information: Some(SignatureInformationSettings {
-                        documentation_format: Some(vec![MarkupKind::PlainText]),
+                        documentation_format: Some(vec![
+                            MarkupKind::Markdown,
+                            MarkupKind::PlainText,
+                        ]),
                         parameter_information: None,
                     }),
                     ..SignatureHelpCapability::default()

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -1,4 +1,5 @@
 use crate::context::*;
+use crate::markdown::markdown_to_kak;
 use crate::types::*;
 use crate::util::*;
 use itertools::Itertools;
@@ -65,7 +66,10 @@ pub fn editor_hover(
                 .filter(|x| !x.is_empty())
                 .map(|x| format!("• {}", x))
                 .join("\n"),
-            HoverContents::Markup(contents) => contents.value,
+            HoverContents::Markup(contents) => match contents.kind {
+                MarkupKind::PlainText => contents.value,
+                MarkupKind::Markdown => markdown_to_kak(&contents.value),
+            },
         },
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod editor_transport;
 mod general;
 mod language_features;
 mod language_server_transport;
+mod markdown;
 mod position;
 mod project_root;
 mod session;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,0 +1,183 @@
+use pulldown_cmark::{Event, Parser, Tag};
+use std::fmt::Write;
+
+pub fn markdown_to_kak(text: &str) -> String {
+    let mut out = String::new();
+    let mut in_italic = false;
+    let mut in_bold = false;
+    let mut in_code_block = false;
+    let mut in_blockquote = false;
+    let emit_style = |out: &mut String, in_italic, in_bold| {
+        write!(
+            out,
+            "{{{}{}{}}}",
+            if in_italic || in_bold { "+" } else { "" },
+            if in_italic { "i" } else { "" },
+            if in_bold { "b" } else { "" },
+        )
+        .unwrap();
+    };
+    for event in Parser::new(text) {
+        match event {
+            Event::Start(Tag::Paragraph) => {}
+            Event::End(Tag::Paragraph) => {
+                out.push_str("\n\n");
+            }
+            Event::Start(Tag::Heading(n)) => {
+                (0..n).for_each(|_| out.push('#'));
+                out.push(' ');
+            }
+            Event::End(Tag::Heading(_)) => {
+                out.push('\n');
+            }
+            Event::Start(Tag::BlockQuote) => {
+                in_blockquote = true;
+            }
+            Event::End(Tag::BlockQuote) => {
+                in_blockquote = false;
+            }
+            Event::Start(Tag::CodeBlock(_)) => {
+                in_code_block = true;
+            }
+            Event::End(Tag::CodeBlock(_)) => {
+                in_code_block = false;
+                out.push('\n');
+            }
+            Event::Start(Tag::List(_)) => {
+                // TODO
+            }
+            Event::End(Tag::List(_)) => {
+                // TODO
+            }
+            Event::Start(Tag::Item) => {
+                out.push_str("- ");
+            }
+            Event::End(Tag::Item) => {}
+            Event::Start(Tag::FootnoteDefinition(_)) => {}
+            Event::End(Tag::FootnoteDefinition(_)) => {}
+            Event::Start(Tag::Table(_))
+            | Event::End(Tag::Table(_))
+            | Event::Start(Tag::TableHead)
+            | Event::End(Tag::TableHead)
+            | Event::Start(Tag::TableRow)
+            | Event::End(Tag::TableRow)
+            | Event::Start(Tag::TableCell)
+            | Event::End(Tag::TableCell) => {
+                // Disabled extension
+            }
+            Event::Start(Tag::Emphasis) => {
+                in_italic = true;
+                emit_style(&mut out, in_italic, in_bold);
+            }
+            Event::End(Tag::Emphasis) => {
+                in_italic = false;
+                emit_style(&mut out, in_italic, in_bold);
+            }
+            Event::Start(Tag::Strong) => {
+                in_bold = true;
+                emit_style(&mut out, in_italic, in_bold);
+            }
+            Event::End(Tag::Strong) => {
+                in_bold = false;
+                emit_style(&mut out, in_italic, in_bold);
+            }
+            Event::Start(Tag::Strikethrough) | Event::End(Tag::Strikethrough) => {
+                // Disabled extension
+            }
+            Event::Start(Tag::Link(..)) => {
+                // TODO
+            }
+            Event::End(Tag::Link(..)) => {
+                // TODO
+            }
+            Event::Start(Tag::Image(..)) => {
+                // TODO
+            }
+            Event::End(Tag::Image(..)) => {
+                // TODO
+            }
+            Event::Text(text) | Event::Html(text) | Event::FootnoteReference(text) => {
+                if in_code_block {
+                    for line in text.as_ref().split('\n').filter(|x| !x.is_empty()) {
+                        out.push_str("  ");
+                        out.push_str(line);
+                        out.push('\n');
+                    }
+                } else if in_blockquote {
+                    for line in text.as_ref().split('\n').filter(|x| !x.is_empty()) {
+                        out.push_str("> ");
+                        out.push_str(line);
+                        out.push('\n');
+                    }
+                } else {
+                    out.push_str(text.as_ref());
+                }
+            }
+            Event::Code(text) => {
+                for line in text.as_ref().split('\n').filter(|x| !x.is_empty()) {
+                    out.push_str("  ");
+                    out.push_str(line);
+                    out.push('\n');
+                }
+            }
+            Event::SoftBreak => {
+                if !in_code_block && !in_blockquote {
+                    out.push(' ');
+                }
+            }
+            Event::HardBreak => {
+                out.push('\n');
+            }
+            Event::Rule => out.push_str("\n---\n"),
+            Event::TaskListMarker(_) => {
+                // Disabled extension
+            }
+        }
+    }
+    out.trim_end_matches('\n').to_owned()
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::markdown_to_kak;
+
+    #[test]
+    fn markdown() {
+        let cases = [
+            ("# Single header", "# Single header"),
+            ("## Double header", "## Double header"),
+            ("#Invalid header", "#Invalid header"),
+            ("Paragraph A\n\n\nParagraph B", "Paragraph A\n\nParagraph B"),
+            (
+                "Paragraph A\n\n\n\nParagraph B",
+                "Paragraph A\n\nParagraph B",
+            ),
+            ("Line A\nLine B", "Line A Line B"),
+            ("```code block```", "  code block"),
+            ("```\ncode block\n```", "  code block"),
+            (
+                "```\ncode block\nsecond line\nthird line\n```",
+                "  code block\n  second line\n  third line",
+            ),
+            ("*italic*", "{+i}italic{}"),
+            ("**bold**", "{+b}bold{}"),
+            ("***bold italic***", "{+i}{+ib}bold italic{+i}{}"),
+            (
+                "***bold italic**just italic*",
+                "{+i}{+ib}bold italic{+i}just italic{}",
+            ),
+            ("> blockquote single line", "> blockquote single line"),
+            (
+                ">blockquote single line no space",
+                "> blockquote single line no space",
+            ),
+            ("> blockquote\n> multi line", "> blockquote\n> multi line"),
+            ("https://some-uri.tld", "https://some-uri.tld"),
+            ("<https://some-uri.tld>", "https://some-uri.tld"),
+            ("[link name](https://some-uri.tld)", "link name"), // TODO: improve
+        ];
+        for (case, wanted) in cases.iter() {
+            assert_eq!(*wanted, markdown_to_kak(case));
+        }
+    }
+}


### PR DESCRIPTION
![](https://tadeo.ca/u/deWdP.png)

Fixes #73

To do:
- [ ] Better link formatting
- [ ] Integrate it into other places, not just hover
- [ ] Set the preferred format back to plaintext
- [ ] Use the right name of the crate in the commit message