### PR TITLE
WIP: textDocument/selectionRange support

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -782,7 +782,7 @@ method    = "rust-analyzer/inlayHints"
 
 # semantic tokens
 
-define-command lsp-semantic-tokens -docstring "semantic-tokens-update: Request semantic tokens" %{
+define-command lsp-semantic-tokens -docstring "lsp-semantic-tokens: Request semantic tokens" %{
   lsp-did-change-and-then lsp-semantic-tokens-request
 }
 
@@ -796,6 +796,26 @@ version   = %d
 method    = "textDocument/semanticTokens"
 [params]
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
+# expand-selection
+
+define-command lsp-expand-selection -docstring "lsp-expand-selection: Expand selection" %{
+  lsp-did-change-and-then lsp-expand-selection-request
+}
+
+define-command -hidden lsp-expand-selection-request %{
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "textDocument/selectionRange"
+[params.position]
+line      = %d
+column    = %d
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
 ### Response handling ###

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -244,6 +244,9 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         request::SemanticTokensRequest::METHOD => {
             semantic_tokens::tokens_request(meta, params, ctx);
         }
+        request::SelectionRangeRequest::METHOD => {
+            selection_range::expand_selection(meta, params, ctx);
+        }
 
         // CCLS
         ccls::NavigateRequest::METHOD => {

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -11,6 +11,7 @@ pub mod implementation;
 pub mod references;
 pub mod rename;
 pub mod rust_analyzer;
+pub mod selection_range;
 pub mod semantic_highlighting;
 pub mod semantic_tokens;
 pub mod signature_help;

--- a/src/language_features/selection_range.rs
+++ b/src/language_features/selection_range.rs
@@ -1,0 +1,63 @@
+use crate::context::Context;
+use crate::position::{kakoune_position_to_lsp, lsp_range_to_kakoune};
+use crate::types::{EditorMeta, EditorParams, PositionParams};
+use crate::util::editor_quote;
+use lsp_types::request::SelectionRangeRequest;
+use lsp_types::{SelectionRange, SelectionRangeParams, TextDocumentIdentifier};
+use serde::Deserialize;
+use url::Url;
+
+pub fn expand_selection(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let document = match ctx.documents.get(&meta.buffile) {
+        Some(document) => document,
+        None => return,
+    };
+    let params = PositionParams::deserialize(params).unwrap();
+    let req_params = SelectionRangeParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        positions: vec![kakoune_position_to_lsp(
+            &params.position,
+            &document.text,
+            &ctx.offset_encoding,
+        )],
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    ctx.call::<SelectionRangeRequest, _>(meta, req_params, move |ctx, meta, result| {
+        editor_expand_selection(meta, result, ctx);
+    });
+}
+
+pub fn editor_expand_selection(
+    meta: EditorMeta,
+    result: Option<Vec<SelectionRange>>,
+    ctx: &mut Context,
+) {
+    let result = result.unwrap_or_else(Vec::new);
+    let (result, client, document) = match (
+        result.first(),
+        &meta.client,
+        ctx.documents.get(&meta.buffile),
+    ) {
+        (Some(result), Some(client), Some(document)) => (result, client, document),
+        _ => return,
+    };
+    let range = lsp_range_to_kakoune(
+        result
+            .parent
+            .as_ref()
+            .map(|x| &x.range)
+            .unwrap_or(&result.range),
+        &document.text,
+        &ctx.offset_encoding,
+    );
+    let command = format!("edit {}; select {}", &meta.buffile, range);
+    let command = format!(
+        "eval -client {} {}",
+        editor_quote(&client),
+        editor_quote(&command),
+    );
+    ctx.exec(meta, command);
+}


### PR DESCRIPTION
WIP because while the current implementation does *something*, it's not very useful. It should probably send the entire hierarchy of selections to the client, so it can go back and forth between them until the cursor moves outside?