### PR TITLE
Add official terraform language server

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -175,3 +175,9 @@ args = ["-c", "if command -v rustup >/dev/null; then $(rustup which rls); else r
 # roots = ["Cargo.toml"]
 # command = "sh"
 # args = ["-c", "if command -v rustup >/dev/null; then $(rustup which rust-analyzer); else rust-analyzer; fi"]
+
+[language.terraform]
+filetypes = ["terraform"]
+roots = ["*.tf"]
+command = "terraform-ls"
+args = ["serve"]


### PR DESCRIPTION
At the moment there are two language server implementations. 
I would pick the [offical](https://github.com/hashicorp/terraform-ls) one, since it will work with more terraform versions.