### PR TITLE
Escape inlay diagnostics that contain double quotes

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -87,13 +87,13 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         .join(" ");
     // Always show a space on line one if no other highlighter is there,
     // to make sure the column always has the right width
-    // Also wrap it in another eval and quotes, to make sure the %opt[] tags are expanded
+    // Also wrap line_flags in another eval and quotes, to make sure the %opt[] tags are expanded
     let command = format!(
         "set buffer lsp_diagnostic_error_count {}
          set buffer lsp_diagnostic_warning_count {}
          set buffer lsp_errors {} {}
          eval \"set buffer lsp_error_lines {} {} '0| '\"
-         eval \"set buffer lsp_diagnostics {} {}\"",
+         set buffer lsp_diagnostics {} {}",
         error_count,
         warning_count,
         version,


### PR DESCRIPTION
Commit 155b21f (Inlay diagnostics support) copies an eval which is used
to interpret %opt[] tags in line_flags.  It's not necessary here;
diagnostic_ranges is a range-specs which we feed the literal position, some
markup and the diagnostic message from the language server. Clarify that in
the comment. No test, but reproducible with gopls:

	printf 'package main\nimport "encoding/json"' > test.go
	kak -e 'lsp-inlay-diagnostics-enable global; lsp-enable' test.go

Fixes #352

@ul I don't think I have write access yet, otherwise I'd push directly to master if I'm confident in a change.