### PR TITLE
Add support for gopls and Dart lsp placeholders

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1455,10 +1455,11 @@ def lsp-snippets-insert -hidden -params 1 %[
             # select things that look like placeholders
             # this regex is not as bad as it looks
             eval -draft %[
-                exec s((?<lt>!\\)(\\\\)*|\A)\K(\$(\d+|\{(\d+(:(\\\}|[^}])+)?)\}))<ret>
+                exec s((?<lt>!\\)(\\\\)*|\A)\K(\$(\d+|\{(\d+(:(\\\}|[^}])*)?)\}))<ret>
                 # tests
                 # $1                - ok
                 # ${2}              - ok
+                # ${3:}             - ok
                 # $1$2$3            - ok x3
                 # $1${2}$3${4}      - ok x4
                 # $1\${2}\$3${4}    - ok, not ok, not ok, ok


### PR DESCRIPTION
Hi! I've made this change in order to fix #390 and #370. The new regex still matches all the current placeholders' formats and additionally matches `gopls` style placeholders (`${1:}`).

Please tell me if everything is OK.