### PR TITLE
make use of eval -verbatim and cosmetic patch

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -81,7 +81,10 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
             };
             editor_quote(&format!(
                 "{}+0|{{{}}}{{\\}}{} {}",
-                pos, face, sep, x.message
+                pos,
+                face,
+                sep,
+                x.message.replace("|", "\\|")
             ))
         })
         .join(" ");
@@ -89,10 +92,10 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
     // to make sure the column always has the right width
     // Also wrap line_flags in another eval and quotes, to make sure the %opt[] tags are expanded
     let command = format!(
-        "set buffer lsp_diagnostic_error_count {}
-         set buffer lsp_diagnostic_warning_count {}
-         set buffer lsp_errors {} {}
-         eval \"set buffer lsp_error_lines {} {} '0| '\"
+        "set buffer lsp_diagnostic_error_count {}; \
+         set buffer lsp_diagnostic_warning_count {}; \
+         set buffer lsp_errors {} {}; \
+         eval \"set buffer lsp_error_lines {} {} '0| '\"; \
          set buffer lsp_diagnostics {} {}",
         error_count,
         warning_count,
@@ -103,12 +106,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         version,
         diagnostic_ranges,
     );
-    let command = format!(
-        "
-        eval -buffer {} {}",
-        editor_quote(buffile),
-        editor_quote(&command)
-    );
+    let command = format!("eval -buffer {} %§{}§", editor_quote(buffile), command.replace("§", "\\§"));
     let meta = EditorMeta {
         session,
         client,
@@ -117,7 +115,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         version,
         fifo: None,
     };
-    ctx.exec(meta, command.to_string());
+    ctx.exec(meta, command);
 }
 
 pub fn editor_diagnostics(meta: EditorMeta, ctx: &mut Context) {

--- a/src/editor_transport.rs
+++ b/src/editor_transport.rs
@@ -102,14 +102,13 @@ pub fn start(config: &Config, initial_request: Option<String>) -> Result<EditorT
 }
 
 pub fn start_unix(path: &path::PathBuf, sender: Sender<EditorRequest>) {
-    let listener = UnixListener::bind(&path);
-
-    if listener.is_err() {
-        error!("Failed to bind {}", path.to_str().unwrap());
-        return;
-    }
-
-    let listener = listener.unwrap();
+    let listener = match UnixListener::bind(&path) {
+        Ok(listener) => listener,
+        Err(e) => {
+            error!("Failed to bind: {}", e);
+            return;
+        }
+    };
 
     for stream in listener.incoming() {
         match stream {

--- a/src/language_features/ccls.rs
+++ b/src/language_features/ccls.rs
@@ -386,8 +386,8 @@ pub fn publish_semantic_highlighting(params: Params, ctx: &mut Context) {
         })
         .join(" ");
     let command = format!(
-        "eval -buffer %§{}§ %§set buffer cquery_semhl {} {}§",
-        buffile, meta.version, ranges
+        "eval -buffer {} -verbatim -- set buffer cquery_semhl {} {}",
+        editor_quote(buffile), meta.version, ranges
     );
-    ctx.exec(meta, command.to_string());
+    ctx.exec(meta, command);
 }

--- a/src/language_features/clangd.rs
+++ b/src/language_features/clangd.rs
@@ -22,7 +22,7 @@ pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
         move |ctx: &mut Context, meta, response| match response {
             Some(response) => {
               let command = format!(
-                "evaluate-commands -try-client %opt{{jumpclient}} %{{edit {}}}",
+                "eval -try-client %opt{{jumpclient}} -verbatim -- edit -existing {}",
                  editor_quote(response.to_file_path().unwrap().to_str().unwrap()),
               );
               ctx.exec(meta, command);

--- a/src/language_features/codeaction.rs
+++ b/src/language_features/codeaction.rs
@@ -55,16 +55,16 @@ pub fn editor_code_actions(
         None => return,
     };
 
+    if result.is_empty() {
+        ctx.exec(meta, format!("lsp-show-error 'No actions available'"));
+        return;
+    }
+
     for cmd in &result {
         match cmd {
             CodeActionOrCommand::Command(cmd) => info!("Command: {:?}", cmd),
             CodeActionOrCommand::CodeAction(action) => info!("Action: {:?}", action),
         }
-    }
-
-    if result.is_empty() {
-        ctx.exec(meta, format!("lsp-show-error 'No actions available'"));
-        return;
     }
 
     let menu_args = result

--- a/src/language_features/cquery.rs
+++ b/src/language_features/cquery.rs
@@ -191,9 +191,9 @@ pub fn publish_semantic_highlighting(params: Params, ctx: &mut Context) {
         .join(" ");
     let command = format!("set buffer cquery_semhl {} {}", version, ranges);
     let command = format!(
-        "eval -buffer {} {}",
+        "eval -buffer {} -verbatim -- {}",
         editor_quote(buffile),
-        editor_quote(&command)
+        command
     );
     let meta = EditorMeta {
         session,
@@ -203,5 +203,5 @@ pub fn publish_semantic_highlighting(params: Params, ctx: &mut Context) {
         version,
         fifo: None,
     };
-    ctx.exec(meta, command.to_string());
+    ctx.exec(meta, command);
 }

--- a/src/language_features/goto.rs
+++ b/src/language_features/goto.rs
@@ -41,7 +41,7 @@ pub fn goto_location(meta: EditorMeta, Location { uri, range }: &Location, ctx: 
     if let Some(contents) = get_file_contents(path_str, ctx) {
         let pos = lsp_range_to_kakoune(&range, &contents, ctx.offset_encoding).start;
         let command = format!(
-            "evaluate-commands -try-client %opt{{jumpclient}} %{{edit {} {} {}}}",
+            "eval -try-client %opt{{jumpclient}} -verbatim -- edit -existing {} {} {}",
             editor_quote(path_str),
             pos.line,
             pos.column,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -77,10 +77,10 @@ pub fn editor_hover(
     }
 
     let command = format!(
-        "lsp-show-hover {} {} {}",
+        "lsp-show-hover {} %§{}§ %§{}§",
         params.position,
-        editor_quote(&contents),
-        editor_quote(&diagnostics)
+        contents.replace("§", "\\§"),
+        diagnostics.replace("§", "\\§")
     );
 
     ctx.exec(meta, command);

--- a/src/language_features/rust_analyzer.rs
+++ b/src/language_features/rust_analyzer.rs
@@ -86,14 +86,14 @@ pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: 
         .join(" ");
     let command = format!(
         "set buffer rust_analyzer_inlay_hints {} {}",
-        meta.version, &ranges
+        meta.version, ranges
     );
     let command = format!(
-        "eval -buffer {} {}",
+        "eval -buffer {} -verbatim -- {}",
         editor_quote(&meta.buffile),
-        editor_quote(&command)
+        command
     );
-    ctx.exec(meta, command.to_string())
+    ctx.exec(meta, command)
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -202,17 +202,17 @@ pub fn apply_source_change(meta: EditorMeta, params: ExecuteCommandParams, ctx: 
                 },
             };
             let command = format!(
-                "evaluate-commands -try-client %opt{{jumpclient}} %{{edit {} {} {}}}",
+                "eval -try-client %opt{{jumpclient}} -verbatim -- edit -existing {} {} {}",
                 editor_quote(buffile),
                 position.line,
                 position.column - 1
             );
             let command = format!(
-                "eval -client {} {}",
+                "eval -client {} -verbatim -- {}",
                 editor_quote(client),
-                editor_quote(&command)
+                command
             );
-            ctx.exec(meta, command.to_string());
+            ctx.exec(meta, command);
         }
         _ => {}
     }

--- a/src/language_features/semantic_highlighting.rs
+++ b/src/language_features/semantic_highlighting.rs
@@ -91,18 +91,16 @@ pub fn editor_update(meta: EditorMeta, params: EditorParams, ctx: &mut Context) 
 }
 
 pub fn debug_scopes(meta: EditorMeta, ctx: &mut Context) {
-    let semhl = ctx
+    let scopes = ctx
         .capabilities
         .as_ref()
-        .unwrap()
-        .semantic_highlighting
-        .as_ref();
-    semhl.map(|sh| {
-        if sh.scopes.is_some() {
-            let command = format!("echo -debug %§{:?}§", sh.scopes.as_ref().unwrap());
-            ctx.exec(meta, command.to_string());
-        }
-    });
+        .and_then(|x| x.semantic_highlighting.as_ref())
+        .and_then(|x| x.scopes.as_ref());
+
+    if let Some(scopes) = scopes {
+        let command = format!("echo -debug %§{:?}§", scopes);
+        ctx.exec(meta, command);
+    }
 }
 
 pub fn make_scope_map(ctx: &mut Context) -> std::vec::Vec<std::string::String> {
@@ -113,18 +111,11 @@ pub fn make_scope_map(ctx: &mut Context) -> std::vec::Vec<std::string::String> {
         .map(|(k, v)| (k.replace("_", "."), v))
         .collect();
 
-    let scopes = ctx
-        .capabilities
+    ctx.capabilities
         .as_ref()
         .and_then(|x| x.semantic_highlighting.as_ref())
-        .and_then(|x| x.scopes.as_ref());
-
-    if scopes.is_none() {
-        return Vec::new();
-    }
-    let scopes = scopes.unwrap();
-
-    map_scopes_to_faces(scopes, faces)
+        .and_then(|x| x.scopes.as_ref())
+        .map_or(Vec::new(), |v| map_scopes_to_faces(v, faces))
 }
 
 fn map_scopes_to_faces(

--- a/src/language_features/semantic_highlighting.rs
+++ b/src/language_features/semantic_highlighting.rs
@@ -21,11 +21,11 @@ pub fn semantic_highlighting_notification(params: Params, ctx: &mut Context) {
         .insert(buffile.to_string(), params.lines);
     let command = "lsp-update-semantic-highlighting";
     let command = format!(
-        "eval -buffer {} {}",
+        "eval -buffer {} -verbatim -- {}",
         editor_quote(&buffile),
-        editor_quote(&command)
+        command
     );
-    ctx.exec(meta, command.to_string());
+    ctx.exec(meta, command);
 }
 
 #[derive(Deserialize)]
@@ -83,11 +83,11 @@ pub fn editor_update(meta: EditorMeta, params: EditorParams, ctx: &mut Context) 
         meta.version, &ranges
     );
     let command = format!(
-        "eval -buffer {} {}",
+        "eval -buffer {} -verbatim -- {}",
         editor_quote(&buffile),
-        editor_quote(&command)
+        command
     );
-    ctx.exec(meta, command.to_string());
+    ctx.exec(meta, command);
 }
 
 pub fn debug_scopes(meta: EditorMeta, ctx: &mut Context) {

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -82,9 +82,9 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
         meta.version, &ranges
     );
     let command = format!(
-        "eval -buffer {} {}",
+        "eval -buffer {} -verbatim -- {}",
         editor_quote(&meta.buffile),
-        editor_quote(&command)
+        command
     );
-    ctx.exec(meta, command.to_string())
+    ctx.exec(meta, command)
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -144,18 +144,17 @@ fn lsp_range_to_kakoune_utf_8_code_units(range: &Range) -> KakouneRange {
     */
     let bol_insert = insert && end.character == 0;
     let start_byte = start.character;
-    let end_byte;
 
     // Exclusive->inclusive range.end conversion will make 0-length LSP range into the reversed
     // 2-length Kakoune range, but we want 1-length (the closest to 0 it can get in Kakoune ;-)).
-    if insert {
-        end_byte = start_byte;
+    let end_byte = if insert {
+        start_byte
     } else if end.character > 0 {
         // -1 because LSP ranges are exclusive, but Kakoune's are inclusive.
-        end_byte = end.character - 1;
+        end.character - 1
     } else {
-        end_byte = EOL_OFFSET - 1;
-    }
+        EOL_OFFSET - 1
+    };
 
     let end_line = if bol_insert || end.character > 0 {
         end.line


### PR DESCRIPTION
This patch makes use of `eval -verbatim` so there is no need to call [editor_quote](https://github.com/kak-lsp/kak-lsp/blob/07f092ed37712534c7ac3fc2117b54da7a9d94cd/src/util.rs#L114) for subsequent command. Side effect is some performance gain, as no extra allocation is done for each `to_editor` command call.

I've tested mostly with `rust-analyzer` and found no regression or any errors.