### PR TITLE
Elaborate/clarify on `lsp` user mode

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -164,7 +164,7 @@ even if Kakoune session is still up and running. Change `server.timeout` in `kak
 duration, or set it to 0 to disable this behaviour. In any scenario making new request would lead to
 attempt to spin up server if it is down.
 
-* `lsp` user mode (see https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#user-modes[Kakoune docs] for more details about user modes):
+* The `lsp` user mode is declared, but has no keybinding yet (see https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#user-modes[Kakoune docs] for more details about user modes):
 
 |===
 | Binding | Command


### PR DESCRIPTION
For me, it is(/was) not clear that the [LSP user mode](https://github.com/kak-lsp/kak-lsp/blob/master/README.asciidoc#usage) didn't have a key combination yet, but is declared.
The linking to kakoune docs didn't totally clarify everything, I'll raise another issue there to see how the [key mapping of user modes](https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#user-modes) should be done exactly.

(Was writing an issue, but proposed directly the little change instead)