### PR TITLE
no need to pass client where buffer context is known

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -730,14 +730,13 @@ rm -rf ${tmp}
 define-command lsp-update-semantic-highlighting -hidden %{
     nop %sh{ (printf '
 session      = "%s"
-client       = "%s"
 buffile      = "%s"
 filetype     = "%s"
 version      = %d
 method       = "update-semantic-highlighting"
 [params]
 current = "%s"
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_lsp_semantic_highlighting}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null }
+' "${kak_session}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_lsp_semantic_highlighting}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null }
 }
 
 # CCLS Extension
@@ -904,13 +903,12 @@ define-command rust-analyzer-inlay-hints -docstring "rust-analyzer-inlay-hints: 
 define-command -hidden rust-analyzer-inlay-hints-request %{
     nop %sh{ (printf '
 session   = "%s"
-client    = "%s"
 buffile   = "%s"
 filetype  = "%s"
 version   = %d
 method    = "rust-analyzer/inlayHints"
 [params]
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+' "${kak_session}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
 # semantic tokens
@@ -922,13 +920,12 @@ define-command lsp-semantic-tokens -docstring "semantic-tokens-update: Request s
 define-command -hidden lsp-semantic-tokens-request %{
     nop %sh{ (printf '
 session   = "%s"
-client    = "%s"
 buffile   = "%s"
 filetype  = "%s"
 version   = %d
 method    = "textDocument/semanticTokens/full"
 [params]
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+' "${kak_session}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
 ### Response handling ###


### PR DESCRIPTION
Some request like `update-semantic-highlighting`, `rust-analyzer/inlayHints` and `textDocument/semanticTokens/full` produce `eval -buffer ...` command which gets concatenated with `eval -client ...` so end result is recursive `eval` command, like for example:

```
eval -client client0 -verbatim -- eval -buffer '/Users/vbauer/projects/tmp/inlay-test/src/main.rs' -verbatim -- set buffer rust_analyzer_inlay_hints 1 '2.15+0|{InlayHint}{\}: String', module: kak_lsp::editor_transport:84
```

Having commands like `eval -client ... eval -buffer ..` is redundant despite it works. I think client information is not necessary as long as there is known buffer in context.

So removing `client` parameter from aforementioned requests will produce single `eval` command which works as before, but avoids recursion:

```
eval -buffer '/Users/vbauer/projects/tmp/inlay-test/src/main.rs' -verbatim -- set buffer rust_analyzer_inlay_hints 1 '2.15+0|{InlayHint}{\}: String', module: kak_lsp::editor_transport:84
```