### PR TITLE
EditorResponse.command form String to Cow<'static, str> and related refactoring

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -6,6 +6,7 @@ use lsp_types::request::*;
 use lsp_types::*;
 use ropey;
 use serde::Deserialize;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 
@@ -201,11 +202,15 @@ impl Context {
         }
     }
 
-    pub fn exec(&self, meta: EditorMeta, command: String) {
+    pub fn exec<S>(&self, meta: EditorMeta, command: S)
+    where
+        S: Into<Cow<'static, str>>,
+    {
+        let command = command.into();
         match meta.fifo.as_ref() {
             Some(fifo) => {
                 debug!("To editor `{}`: {}", meta.session, command);
-                fs::write(fifo, command).expect("Failed to write command to fifo")
+                fs::write(fifo, command.as_bytes()).expect("Failed to write command to fifo")
             }
             None => {
                 if self

--- a/src/context.rs
+++ b/src/context.rs
@@ -247,12 +247,12 @@ impl Context {
         }
     }
 
-    pub fn meta_for_buffer(&self, buffile: String) -> Option<EditorMeta> {
-        let document = self.documents.get(&buffile)?;
+    pub fn meta_for_buffer(&self, buffile: &str) -> Option<EditorMeta> {
+        let document = self.documents.get(buffile)?;
         Some(EditorMeta {
             session: self.session.clone(),
             client: None,
-            buffile: buffile,
+            buffile: buffile.to_string(),
             filetype: "".to_string(), // filetype is not used by ctx.exec, but it's definitely a code smell
             version: document.version,
             fifo: None,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::context::*;
 use crate::diagnostics;
 use crate::general;
@@ -51,7 +53,7 @@ pub fn start(
                 if to_editor
                     .send(EditorResponse {
                         meta: initial_request.meta,
-                        command,
+                        command: Cow::from(command),
                     })
                     .is_err()
                 {

--- a/src/language_features/ccls.rs
+++ b/src/language_features/ccls.rs
@@ -361,7 +361,7 @@ pub fn publish_semantic_highlighting(params: Params, ctx: &mut Context) {
         Some(document) => document,
         None => return,
     };
-    let meta = match ctx.meta_for_buffer(buffile.to_string()) {
+    let meta = match ctx.meta_for_buffer(buffile) {
         Some(meta) => meta,
         None => return,
     };

--- a/src/language_features/codeaction.rs
+++ b/src/language_features/codeaction.rs
@@ -56,7 +56,7 @@ pub fn editor_code_actions(
     };
 
     if result.is_empty() {
-        ctx.exec(meta, format!("lsp-show-error 'No actions available'"));
+        ctx.exec(meta, "lsp-show-error 'No actions available'");
         return;
     }
 

--- a/src/language_features/formatting.rs
+++ b/src/language_features/formatting.rs
@@ -26,7 +26,7 @@ pub fn editor_formatting(meta: EditorMeta, result: Option<Vec<TextEdit>>, ctx: &
     if document.is_none() {
         // Nothing to do, but sending command back to the editor is required to handle case when
         // editor is blocked waiting for response via fifo.
-        ctx.exec(meta, "nop".to_string());
+        ctx.exec(meta, "nop");
         return;
     }
     let document = document.unwrap();
@@ -34,7 +34,7 @@ pub fn editor_formatting(meta: EditorMeta, result: Option<Vec<TextEdit>>, ctx: &
         None => {
             // Nothing to do, but sending command back to the editor is required to handle case when
             // editor is blocked waiting for response via fifo.
-            ctx.exec(meta, "nop".to_string());
+            ctx.exec(meta, "nop");
             return;
         }
         Some(text_edits) => {

--- a/src/language_features/range_formatting.rs
+++ b/src/language_features/range_formatting.rs
@@ -40,7 +40,7 @@ pub fn editor_range_formatting(meta: EditorMeta, text_edits: Vec<TextEdit>, ctx:
     if text_edits.len() == 0 {
         // Nothing to do, but sending command back to the editor is required to handle case when
         // editor is blocked waiting for response via fifo.
-        ctx.exec(meta, "nop".to_string());
+        ctx.exec(meta, "nop");
         return;
     }
     let document = document.unwrap();

--- a/src/language_features/semantic_highlighting.rs
+++ b/src/language_features/semantic_highlighting.rs
@@ -13,7 +13,7 @@ pub fn semantic_highlighting_notification(params: Params, ctx: &mut Context) {
     let params = params.unwrap();
     let path = params.text_document.uri.to_file_path().unwrap();
     let buffile = path.to_str().unwrap();
-    let meta = match ctx.meta_for_buffer(buffile.to_string()) {
+    let meta = match ctx.meta_for_buffer(buffile) {
         Some(meta) => meta,
         None => return,
     };

--- a/src/language_features/semantic_highlighting.rs
+++ b/src/language_features/semantic_highlighting.rs
@@ -115,7 +115,7 @@ pub fn make_scope_map(ctx: &mut Context) -> std::vec::Vec<std::string::String> {
         .as_ref()
         .and_then(|x| x.semantic_highlighting.as_ref())
         .and_then(|x| x.scopes.as_ref())
-        .map_or(Vec::new(), |v| map_scopes_to_faces(v, faces))
+        .map_or_else(Vec::new, |v| map_scopes_to_faces(v, faces))
 }
 
 fn map_scopes_to_faces(

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use sloggers::file::FileLoggerBuilder;
 use sloggers::terminal::{Destination, TerminalLoggerBuilder};
 use sloggers::types::Severity;
 use sloggers::Build;
+use std::borrow::Cow;
 use std::env;
 use std::fs;
 use std::io::{stdin, Read, Write};
@@ -292,7 +293,7 @@ fn report_config_error(matches: &ArgMatches, session: &str, error: &toml::de::Er
         .sender()
         .send(EditorResponse {
             meta: request.meta,
-            command,
+            command: Cow::from(command),
         })
         .is_err()
     {

--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -227,12 +227,12 @@ pub fn apply_text_edits_to_buffer(
     let command = format!("eval -draft -save-regs '^' {}", editor_quote(&command));
     uri.and_then(|uri| uri.to_file_path().ok())
         .and_then(|path| {
-            path.to_str().and_then(|buffile| {
-                Some(format!(
+            path.to_str().map(|buffile| {
+                format!(
                     "eval -buffer {} {}",
                     editor_quote(buffile),
                     editor_quote(&command)
-                ))
+                )
             })
         })
         .or_else(|| Some(command))

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,7 @@ use jsonrpc_core::{Call, Output, Params};
 use lsp_types::Range;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Error;
@@ -87,7 +88,7 @@ pub struct EditorRequest {
 #[derive(Deserialize)]
 pub struct EditorResponse {
     pub meta: EditorMeta,
-    pub command: String,
+    pub command: Cow<'static, str>,
 }
 
 pub type SessionId = String;

--- a/src/util.rs
+++ b/src/util.rs
@@ -180,11 +180,11 @@ pub fn get_kakoune_position(
 /// Apply text edits to the file pointed by uri either by asking Kakoune to modify corresponding
 /// buffer or by editing file directly when it's not open in editor.
 pub fn apply_text_edits(meta: &EditorMeta, uri: &Url, edits: Vec<TextEdit>, ctx: &Context) {
-    let wrapped_edits = edits
+    let edits = edits
         .into_iter()
         .map(|e| OneOf::Left(e))
-        .collect::<Vec<OneOf<TextEdit, AnnotatedTextEdit>>>();
-    apply_annotated_text_edits(meta, uri, &wrapped_edits[..], ctx)
+        .collect::<Vec<_>>();
+    apply_annotated_text_edits(meta, uri, &edits, ctx)
 }
 
 /// Apply text edits to the file pointed by uri either by asking Kakoune to modify corresponding
@@ -195,18 +195,20 @@ pub fn apply_annotated_text_edits(
     edits: &[OneOf<TextEdit, AnnotatedTextEdit>],
     ctx: &Context,
 ) {
-    if let Some(document) = ctx
-        .documents
-        .get(uri.to_file_path().unwrap().to_str().unwrap())
+    if let Some(document) = uri
+        .to_file_path()
+        .ok()
+        .and_then(|path| path.to_str().and_then(|buffile| ctx.documents.get(buffile)))
     {
-        ctx.exec(
-            meta.clone(),
-            apply_text_edits_to_buffer(Some(uri), edits, &document.text, ctx.offset_encoding),
-        );
-    } else {
-        if let Err(e) = apply_text_edits_to_file(uri, edits, ctx.offset_encoding) {
-            error!("Failed to apply edits to file {} ({})", uri, e);
-        };
+        let meta = meta.clone();
+        match apply_text_edits_to_buffer(Some(uri), edits, &document.text, ctx.offset_encoding) {
+            Some(cmd) => ctx.exec(meta, cmd),
+            // Nothing to do, but sending command back to the editor is required to handle case when
+            // editor is blocked waiting for response via fifo.
+            None => ctx.exec(meta, "nop"),
+        }
+    } else if let Err(e) = apply_text_edits_to_file(uri, edits, ctx.offset_encoding) {
+        error!("Failed to apply edits to file {} ({})", uri, e);
     }
 }
 


### PR DESCRIPTION
This PR brings some optimization as changing type of `EditorResponse.command` form `String` to `Cow<'static, str>`, which I believe won't allocate if called like `ctx.Exec(meta, "slice str")`.

PS: feel free to reject or cherry pick something.