### PR TITLE
rust: fix "unresolved proc macro" warning

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -180,6 +180,20 @@ args = ["-c", "if command -v rustup >/dev/null; then $(rustup which rls); else r
 # roots = ["Cargo.toml"]
 # command = "sh"
 # args = ["-c", "if command -v rustup >/dev/null; then $(rustup which rust-analyzer); else rust-analyzer; fi"]
+#
+# [language.rust.initialization_options]
+#
+# If you get 'unresolved proc macro' warnings, you have two options
+#
+# 1/ The safe choice is two disable the warning:
+# diagnostics.disabled = ["unresolved-proc-macro"]
+#
+# 2/ Or you can opt-in for proc macro support
+# procMacro.enable = true
+# cargo.loadOutDirsFromCheck = true
+#
+# See https://github.com/rust-analyzer/rust-analyzer/issues/6448
+# for details
 
 [language.terraform]
 filetypes = ["terraform"]


### PR DESCRIPTION
I guess kakoune is not able to implement the proc macro expansion (yet?)

So this can save a lot of headaches for rust-analyzer users