### PR TITLE
Expose lsp-{next,previous}-location to traverse any grep-like buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,23 @@ Breaking changes:
 - The configuration syntax for `semantic_tokens` has changed. See the updated `kak-lsp.toml` for an example (#488).
 - Snippet support has been disabled by default, as a workaround for conflicts with Kakoune's built-in completion (#282).
 - `lsp-show-message`, which handles `window/showMessage` requests from the server has been removed. See below for the replacement.
+- Hidden commands `lsp-{next,previous}-match` were removed in favor of `lsp-{next,previous}-location` (#466).
 
 Additions:
 - Default configuration for Julia (#502).
 - `lsp-show-message` has been replaced by four separate commands `lsp-show-message-{error,warning,info,log}`.
   The new default implementations log the given messages from the language server to the debug buffer. Important messages are shown in `%opt{toolsclient}`.
 - `lsp-code-actions` use the `menu` command to select an action interactively. The new command `lsp-show-code-actions` can be overridden to customize this behavior (#367).
+- New commands `lsp-{next,previous}-location` generalize `grep-next-match`, `lsp-next-match` and friends (#466).
+- New option `lsp_location_format` to tell `lsp-{next,previous}-location` which "<file>:<line>"-style to match (#466).
 
 Bug fixes:
 - Fix renaming of Rust lifetimes (#474).
 - The suggested config for `rust-analyzer` was fixed for the case that `rustup` is installed but `rust-analyzer` is not installed via `rustup`.
 - Fix spurious cursor movement on `lsp-rename` and `lsp-rename-prompt` (#504).
+
+Deprecations:
+- `lsp-{goto,symbols}-{next,previous}-match` are deprecated in favor of `lsp-next-location *goto*` and similar (#466).
 
 ## 10.0.0 - 2021-06-03
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -134,7 +134,7 @@ Either way you get:
 * `lsp-references` command to find references to the symbol under the main cursor, mapped to `gr` by default
 ** for the previous five commands, the `\*goto*` buffer has filetype `lsp-goto`, so you can press `<ret>` on a line or use the `lsp-jump` command
 * `lsp-find-error` command to jump to the next or previous error in the current file
-** `lsp-references-previous-match` and `lsp-references-next-match` to navigate between references
+* `lsp-next-location` and `lsp-previous-location` to jump to the next or previous location listed in a buffer with the `lsp-goto` filetype. These also work for buffers `\*grep*`, `\*lint*` and `\*make*`
 * `lsp-highlight-references` command to highlight all references to the symbol under the main cursor in the current buffer with the `Reference` face (which is equal to the `MatchingChar` face by default)
 * `lsp-document-symbol` command to list the current buffer's symbols
 * `lsp-workspace-symbol` command to list project-wide symbols matching the query

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -295,14 +295,6 @@ column    = %d
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
-define-command lsp-goto-next-match -docstring 'Jump to the next goto match' %{
-    lsp-next-match '*goto*'
-}
-
-define-command lsp-goto-previous-match -docstring 'Jump to the previous goto match' %{
-    lsp-previous-match '*goto*'
-}
-
 define-command lsp-highlight-references -docstring "Highlight symbol references" %{
     lsp-did-change-and-then lsp-highlight-references-request
 }
@@ -405,14 +397,6 @@ version  = %d
 method   = "textDocument/documentSymbol"
 [params]
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
-}
-
-define-command lsp-symbols-next-match -docstring 'Jump to the next symbols match' %{
-    lsp-next-match '*symbols*'
-}
-
-define-command lsp-symbols-previous-match -docstring 'Jump to the previous symbols match' %{
-    lsp-previous-match '*symbols*'
 }
 
 define-command -hidden lsp-workspace-symbol-buffer -params 4 -docstring %{
@@ -1688,4 +1672,21 @@ define-command -hidden lsp-diagnostics-open-error -params 4 %{
         echo -markup "{Information}{\}%arg{4}"
         try %{ focus }
     }
+}
+
+# Deprecated commands.
+define-command lsp-symbols-next-match -docstring 'DEPRECATED: use lsp-next-location. Jump to the next symbols match' %{
+    lsp-next-match '*symbols*'
+}
+
+define-command lsp-symbols-previous-match -docstring 'DEPRECATED: use lsp-previous-location. Jump to the previous symbols match' %{
+    lsp-previous-match '*symbols*'
+}
+
+define-command lsp-goto-next-match -docstring 'DEPRECATED: use lsp-next-location. Jump to the next goto match' %{
+    lsp-next-match '*goto*'
+}
+
+define-command lsp-goto-previous-match -docstring 'DEPRECATED: use lsp-previous-location. Jump to the previous goto match' %{
+    lsp-previous-match '*goto*'
 }

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -945,13 +945,7 @@ define-command -hidden lsp-show-diagnostics -params 2 -docstring "Render diagnos
         edit! -scratch *diagnostics*
         set-option buffer filetype lsp-goto
         set-option buffer lsp_project_root "%arg{1}/"
-
-        # This buffer behaves a bit like a *make* buffer.
         alias buffer lsp-jump lsp-diagnostics-jump
-        remove-highlighter window/lsp-goto
-        add-highlighter window/lsp-diagnostics ref lsp-diagnostics
-        hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/lsp-diagnostics }
-
         set-register '"' %arg{2}
         execute-keys Pgg
     }
@@ -1619,11 +1613,6 @@ hook -group lsp-goto-highlight global WinSetOption filetype=lsp-goto %{ # from g
     add-highlighter window/lsp-goto/ line %{%opt{grep_current_line}} default+b
     hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/lsp-goto }
 }
-
-add-highlighter shared/lsp-diagnostics group # from make.kak
-add-highlighter shared/lsp-diagnostics/ regex "^((?:\w:)?[^:\n]+):(\d+):(?:(\d+):)?\h+(?:((?:fatal )?error)|(warning)|(note)|(required from(?: here)?))?.*?$" 1:cyan 2:green 3:green 4:red 5:yellow 6:blue 7:yellow
-add-highlighter shared/lsp-diagnostics/ regex "^\h*(~*(?:(\^)~*)?)$" 1:green 2:cyan+b
-add-highlighter shared/lsp-diagnostics/ line '%opt{grep_current_line}' default+b
 
 hook global WinSetOption filetype=lsp-goto %{
     hook buffer -group lsp-goto-hooks NormalKey <ret> lsp-jump


### PR DESCRIPTION
These commands work for any grep-like buffer - the user just needs to pass
`%val{bufname}` as first argument for example `*goto*`, or `*grep*` [1].

I find this very convenient because it makes it trivial to define a command
that allows to go to the next/previous location in any kind of grep buffer.
This works for all lsp buffers with filetype `lsp-goto` as well as for `grep`,
`lint` and `make` buffers:

	declare-option -hidden str last_used_grep_buffer
	hook -group my global WinDisplay \
		\*(?:diagnostics|goto|find|grep|implementations|lint-output|make|references|symbols)\* %{
		set-option global last_used_grep_buffer %val{bufname}
	}
	map global normal <c-n> %{: lsp-next-location %opt{last_used_grep_buffer}<ret>} -docstring 'lsp next'
	map global normal <c-p> %{: lsp-previous-location %opt{last_used_grep_buffer}<ret>} -docstring 'lsp previous'

This was originally posted as
https://discuss.kakoune.com/t/single-command-for-grep-next-match-in-similar-buffers-lsp-make-find/1215
I wonder if something like this should be the default in future.

[1]: Or `%val{buffile}` which is equivalent to `%val{bufname}` for `*grep*` and friends.