### PR TITLE
Add rootPath for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ Bug fixes:
 - `lsp-show-{diagnostics,goto-choices,document-symbols}` no longer `cd` to the project root (#454).
 - Fix error when the documentation part of a completion item starts with a dash (`-`) (#460).
 - Fix completions of non-ASCII characters when using textEdit (which is not only partially supported) (#455).
+- Fix `lsp-rename` with `pyright` (#468).
 
 For release notes on v9.0.0 and older see <https://github.com/kak-lsp/kak-lsp/releases>.

--- a/src/general.rs
+++ b/src/general.rs
@@ -280,7 +280,7 @@ pub fn initialize(
         initialization_options,
         process_id: Some(process::id()),
         root_uri: Some(Url::from_file_path(root_path).unwrap()),
-        root_path: None,
+        root_path: Some(root_path.to_string()),
         trace: Some(TraceOption::Off),
         workspace_folders: None,
         client_info: Some(ClientInfo {


### PR DESCRIPTION
I'm not sure if this will break other language servers - since both rootPath and rootUri are deprecated, pyright only supports rootPath, but not rootUri, so this was essential in getting pyright working. However, kak-lsp should be moving to workspaceFolders going forwards. I tried it but could not get it working, so hopefully this will do.