### PR TITLE
Change ocaml command to ocamllsp

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -139,8 +139,7 @@ command = "rnix-lsp"
 [language.ocaml]
 filetypes = ["ocaml"]
 roots = ["Makefile", "opam", "*.opam", "dune"]
-command = "ocaml-language-server"
-args = ["--stdio"]
+command = "ocamllsp"
 
 [language.php]
 filetypes = ["php"]


### PR DESCRIPTION
The https://github.com/ocaml-lsp/ocaml-language-server project has been archived, it is not receiving updates anymore.

https://github.com/ocaml/ocaml-lsp is the currently supported "blessed" LSP server (note how it's under the ocaml org).
Its executable is called ocamllsp and it only supports stdio mode (there's no stdio flag).