### PR TITLE
Fix warning during compilation

### DIFF
--- a/src/thread_worker.rs
+++ b/src/thread_worker.rs
@@ -1,6 +1,7 @@
 //! Small utility to correctly spawn crossbeam-channel based worker threads.
 //! Original source: https://github.com/rust-analyzer/rust-analyzer/blob/c7ceea82a5ab8aabab2f98e7c1e1ec94e82087c2/crates/thread_worker/src/lib.rs
 
+use std::panic;
 use std::thread;
 
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
@@ -26,7 +27,7 @@ impl Drop for ScopedThread {
         // escalate panic, but avoid aborting the process
         if let Err(e) = res {
             if !thread::panicking() {
-                panic!(e)
+                panic::panic_any(e);
             }
         }
     }


### PR DESCRIPTION
This commit fixes the following warning that occurs during compilation:

```
warning: panic message is not a string literal
  --> src/thread_worker.rs:29:24
   |
29 |                 panic!(e)
   |                        ^
   |
   = note: `#[warn(non_fmt_panic)]` on by default
   = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
   |
29 |                 panic!("{}", e)
   |                        ^^^^^
help: or use std::panic::panic_any instead
   |
29 |                 std::panic::panic_any(e)
   |                 ^^^^^^^^^^^^^^^^^^^^^^

warning: 1 warning emitted
```