### PR TITLE
Implement WorkspaceConfiguration request

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -332,6 +332,12 @@ fn dispatch_server_request(request: MethodCall, ctx: &mut Context) {
         }
         _ => {
             warn!("Unsupported method: {}", method);
+            ctx.reply(
+                request.id,
+                Err(jsonrpc_core::Error::new(
+                    jsonrpc_core::ErrorCode::MethodNotFound,
+                )),
+            )
         }
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -326,24 +326,20 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
 
 fn dispatch_server_request(request: MethodCall, ctx: &mut Context) {
     let method: &str = &request.method;
-    match method {
+    let result = match method {
         request::ApplyWorkspaceEdit::METHOD => {
-            workspace::apply_edit_from_server(request.id, request.params, ctx);
+            workspace::apply_edit_from_server(request.params, ctx)
         }
-        request::WorkspaceConfiguration::METHOD => {
-            let result = workspace::configuration(request.params, ctx);
-            ctx.reply(request.id, result);
-        }
+        request::WorkspaceConfiguration::METHOD => workspace::configuration(request.params, ctx),
         _ => {
             warn!("Unsupported method: {}", method);
-            ctx.reply(
-                request.id,
-                Err(jsonrpc_core::Error::new(
-                    jsonrpc_core::ErrorCode::MethodNotFound,
-                )),
-            )
+            Err(jsonrpc_core::Error::new(
+                jsonrpc_core::ErrorCode::MethodNotFound,
+            ))
         }
-    }
+    };
+
+    ctx.reply(request.id, result);
 }
 
 fn dispatch_server_notification(method: &str, params: Params, mut ctx: &mut Context) {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -330,6 +330,10 @@ fn dispatch_server_request(request: MethodCall, ctx: &mut Context) {
         request::ApplyWorkspaceEdit::METHOD => {
             workspace::apply_edit_from_server(request.id, request.params, ctx);
         }
+        request::WorkspaceConfiguration::METHOD => {
+            let result = workspace::configuration(request.params, ctx);
+            ctx.reply(request.id, result);
+        }
         _ => {
             warn!("Unsupported method: {}", method);
             ctx.reply(

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -2,7 +2,7 @@ use crate::context::*;
 use crate::language_features::rust_analyzer;
 use crate::types::*;
 use crate::util::*;
-use jsonrpc_core::{Id, Params};
+use jsonrpc_core::Params;
 use lsp_types::notification::*;
 use lsp_types::request::*;
 use lsp_types::*;
@@ -298,9 +298,12 @@ pub fn apply_edit_from_editor(meta: EditorMeta, params: EditorParams, ctx: &mut 
     apply_edit(meta, edit, ctx);
 }
 
-pub fn apply_edit_from_server(id: Id, params: Params, ctx: &mut Context) {
-    let params: ApplyWorkspaceEditParams = params.parse().expect("Failed to parse params");
+pub fn apply_edit_from_server(
+    params: Params,
+    ctx: &mut Context,
+) -> Result<Value, jsonrpc_core::Error> {
+    let params: ApplyWorkspaceEditParams = params.parse()?;
     let meta = ctx.meta_for_session();
     let response = apply_edit(meta, params.edit, ctx);
-    ctx.reply(id, Ok(serde_json::to_value(response).unwrap()));
+    Ok(serde_json::to_value(response).unwrap())
 }


### PR DESCRIPTION
This implements the `workspace/configuration` server request.

This fixes newer LSP implementations that ignore the content of a `workspace/didConfigurationChange` notification and request configuration explicitly.

Tested with https://github.com/sumneko/lua-language-server.

Fixes #479.
Ref #234.