### PR TITLE
Rework Semantic Token modifiers

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -304,7 +304,75 @@ hook global WinSetOption filetype=<language> %{
 }
 ----
 
-The faces used for semantic tokens and modifiers can be modified in `kak-lsp.toml`, under the `semantic_tokens` and `semantic_token_modifiers` sections. The modifiers are used first if available, and then the main token type is used if no modifier face is specified.
+The faces used for semantic tokens and modifiers can be modified in `kak-lsp.toml`, under the `semantic_tokens` section.
+The syntax for such an entry is
+
+[source,toml]
+----
+[[semantic_tokens]]
+name = "variable"
+face = "const_variable_declaration"
+modifiers = ["constant", "declaration"]
+----
+
+where `name` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `name` and `face` are required.
+
+You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entrie's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry. +
+`kak-lsp` will find the most specific matching configuration to apply, where specificity is defined as the number of matching modifiers. If multiple entries match with the same number of modifiers, the one that was defined last in the configuration wins.
+
+*Example:*
+
+Assuming the following configuration,
+
+[source,toml]
+----
+[[semantic_tokens]]
+name = "variable"
+face = "const_variable_declaration"
+modifiers = ["constant", "declaration"]
+
+[[semantic_tokens]]
+name = "variable"
+face = "const_variable"
+modifiers = ["constant"]
+
+[[semantic_tokens]]
+name = "variable"
+face = "variable"
+----
+
+`kak-lsp` will perform these mappings:
+
+[cols="1,1,2,5"]
+|===
+| Token | Modifiers | Face | Comment
+
+| `variable`
+| `constant`, `declaration`
+| `const_variable_declaration`
+| First entry matches with 2 modifiers.
+
+| `variable`
+| `constant`
+| `const_variable`
+| First and second entry match with 1 modifier, second wins.
+
+| `variable`
+| `declaration`
+| `variable`
+| Only third entry matches. First entry doesn't match, because `constant` is missing.
+
+| `variable`
+|
+| `variable`
+| Third entry matches.
+
+| `function`
+|
+|
+| No entries match and no face is applied.
+
+|===
 
 == Inlay Diagnostics
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -317,7 +317,7 @@ modifiers = ["constant", "declaration"]
 
 where `name` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `name` and `face` are required.
 
-You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entrie's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry. +
+You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entry's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry. +
 `kak-lsp` will find the most specific matching configuration to apply, where specificity is defined as the number of matching modifiers. If multiple entries match with the same number of modifiers, the one that was defined last in the configuration wins.
 
 *Example:*

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -310,12 +310,12 @@ The syntax for such an entry is
 [source,toml]
 ----
 [[semantic_tokens]]
-name = "variable"
+token = "variable"
 face = "const_variable_declaration"
 modifiers = ["constant", "declaration"]
 ----
 
-where `name` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `name` and `face` are required.
+where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `token` and `face` are required.
 
 You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entry's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry. +
 `kak-lsp` will find the most specific matching configuration to apply, where specificity is defined as the number of matching modifiers. If multiple entries match with the same number of modifiers, the one that was defined last in the configuration wins.
@@ -327,17 +327,17 @@ Assuming the following configuration,
 [source,toml]
 ----
 [[semantic_tokens]]
-name = "variable"
+token = "variable"
 face = "const_variable_declaration"
 modifiers = ["constant", "declaration"]
 
 [[semantic_tokens]]
-name = "variable"
+token = "variable"
 face = "const_variable"
 modifiers = ["constant"]
 
 [[semantic_tokens]]
-name = "variable"
+token = "variable"
 face = "variable"
 ----
 

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -2,8 +2,13 @@ snippet_support = true
 verbosity = 2
 
 # Semantic tokens support
-# See https://github.com/microsoft/vscode-languageserver-node/blob/8c8981eb4fb6adec27bf1bb5390a0f8f7df2899e/client/src/semanticTokens.proposed.ts#L288
-# for token/modifier types.
+# See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens
+# for the default list of tokens and modifiers.
+# However, many language servers implement their own values.
+# Make sure to check the output of `lsp-capabilities` and each server's documentation and source code as well.
+# Examples:
+# - TypeScript: https://github.com/microsoft/vscode-languageserver-node/blob/2645fb54ea1e764aff71dee0ecc8aceff3aabf56/client/src/common/semanticTokens.ts#L58
+# - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
 [[semantic_tokens]]
 name = "type"
 face = "type"

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -10,35 +10,35 @@ verbosity = 2
 # - TypeScript: https://github.com/microsoft/vscode-languageserver-node/blob/2645fb54ea1e764aff71dee0ecc8aceff3aabf56/client/src/common/semanticTokens.ts#L58
 # - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
 [[semantic_tokens]]
-name = "type"
+token = "type"
 face = "type"
 
 [[semantic_tokens]]
-name = "variable"
+token = "variable"
 face = "variable"
 
 [[semantic_tokens]]
-name = "namespace"
+token = "namespace"
 face = "module"
 
 [[semantic_tokens]]
-name = "function"
+token = "function"
 face = "function"
 
 [[semantic_tokens]]
-name = "string"
+token = "string"
 face = "string"
 
 [[semantic_tokens]]
-name = "keyword"
+token = "keyword"
 face = "keyword"
 
 [[semantic_tokens]]
-name = "operator"
+token = "operator"
 face = "operator"
 
 [[semantic_tokens]]
-name = "comment"
+token = "comment"
 face = "comment"
 
 [server]

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -4,20 +4,37 @@ verbosity = 2
 # Semantic tokens support
 # See https://github.com/microsoft/vscode-languageserver-node/blob/8c8981eb4fb6adec27bf1bb5390a0f8f7df2899e/client/src/semanticTokens.proposed.ts#L288
 # for token/modifier types.
+[[semantic_tokens]]
+name = "type"
+face = "type"
 
-[semantic_tokens]
-type = "type"
-variable = "variable"
-namespace = "module"
-function = "function"
-string = "string"
-keyword = "keyword"
-operator = "operator"
-comment = "comment"
+[[semantic_tokens]]
+name = "variable"
+face = "variable"
 
-[semantic_token_modifiers]
-documentation = "documentation"
-readonly = "default+d"
+[[semantic_tokens]]
+name = "namespace"
+face = "module"
+
+[[semantic_tokens]]
+name = "function"
+face = "function"
+
+[[semantic_tokens]]
+name = "string"
+face = "string"
+
+[[semantic_tokens]]
+name = "keyword"
+face = "keyword"
+
+[[semantic_tokens]]
+name = "operator"
+face = "operator"
+
+[[semantic_tokens]]
+name = "comment"
+face = "comment"
 
 [server]
 # exit session if no requests were received during given period in seconds

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -10,36 +10,51 @@ verbosity = 2
 # - TypeScript: https://github.com/microsoft/vscode-languageserver-node/blob/2645fb54ea1e764aff71dee0ecc8aceff3aabf56/client/src/common/semanticTokens.ts#L58
 # - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
 [[semantic_tokens]]
-token = "type"
-face = "type"
+token = "comment"
+face = "documentation"
+modifiers = ["documentation"]
 
 [[semantic_tokens]]
-token = "variable"
-face = "variable"
-
-[[semantic_tokens]]
-token = "namespace"
-face = "module"
+token = "comment"
+face = "comment"
 
 [[semantic_tokens]]
 token = "function"
 face = "function"
 
 [[semantic_tokens]]
-token = "string"
-face = "string"
-
-[[semantic_tokens]]
 token = "keyword"
 face = "keyword"
+
+[[semantic_tokens]]
+token = "namespace"
+face = "module"
 
 [[semantic_tokens]]
 token = "operator"
 face = "operator"
 
 [[semantic_tokens]]
-token = "comment"
-face = "comment"
+token = "string"
+face = "string"
+
+[[semantic_tokens]]
+token = "type"
+face = "type"
+
+[[semantic_tokens]]
+token = "variable"
+face = "default+d"
+modifiers = ["readonly"]
+
+[[semantic_tokens]]
+token = "variable"
+face = "default+d"
+modifiers = ["constant"]
+
+[[semantic_tokens]]
+token = "variable"
+face = "variable"
 
 [server]
 # exit session if no requests were received during given period in seconds

--- a/src/general.rs
+++ b/src/general.rs
@@ -8,6 +8,7 @@ use lsp_types::notification::*;
 use lsp_types::request::*;
 use lsp_types::*;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::process;
 use url::Url;
 
@@ -249,16 +250,23 @@ pub fn initialize(
                     token_types: ctx
                         .config
                         .semantic_tokens
-                        .keys()
+                        .iter()
                         .cloned()
-                        .map(|x| x.into())
+                        .map(|token| token.name.into())
+                        // Collect into HashSet first to remove duplicates
+                        .collect::<HashSet<SemanticTokenType>>()
+                        .into_iter()
                         .collect(),
                     token_modifiers: ctx
                         .config
-                        .semantic_token_modifiers
-                        .keys()
+                        .semantic_tokens
+                        .iter()
                         .cloned()
-                        .map(|x| x.into())
+                        // Get all modifiers used in token definitions
+                        .flat_map(|token| token.modifiers)
+                        // Collect into HashSet first to remove duplicates
+                        .collect::<HashSet<SemanticTokenModifier>>()
+                        .into_iter()
                         .collect(),
                     formats: vec![TokenFormat::RELATIVE],
                     overlapping_token_support: None,

--- a/src/general.rs
+++ b/src/general.rs
@@ -251,8 +251,7 @@ pub fn initialize(
                         .config
                         .semantic_tokens
                         .iter()
-                        .cloned()
-                        .map(|token| token.name.into())
+                        .map(|token| token.name.clone().into())
                         // Collect into set first to remove duplicates
                         .collect::<HashSet<SemanticTokenType>>()
                         .into_iter()
@@ -261,9 +260,8 @@ pub fn initialize(
                         .config
                         .semantic_tokens
                         .iter()
-                        .cloned()
                         // Get all modifiers used in token definitions
-                        .flat_map(|token| token.modifiers)
+                        .flat_map(|token| token.modifiers.clone())
                         // Collect into set first to remove duplicates
                         .collect::<HashSet<SemanticTokenModifier>>()
                         .into_iter()

--- a/src/general.rs
+++ b/src/general.rs
@@ -253,7 +253,7 @@ pub fn initialize(
                         .iter()
                         .cloned()
                         .map(|token| token.name.into())
-                        // Collect into HashSet first to remove duplicates
+                        // Collect into set first to remove duplicates
                         .collect::<HashSet<SemanticTokenType>>()
                         .into_iter()
                         .collect(),
@@ -264,7 +264,7 @@ pub fn initialize(
                         .cloned()
                         // Get all modifiers used in token definitions
                         .flat_map(|token| token.modifiers)
-                        // Collect into HashSet first to remove duplicates
+                        // Collect into set first to remove duplicates
                         .collect::<HashSet<SemanticTokenModifier>>()
                         .into_iter()
                         .collect(),

--- a/src/general.rs
+++ b/src/general.rs
@@ -251,7 +251,7 @@ pub fn initialize(
                         .config
                         .semantic_tokens
                         .iter()
-                        .map(|token| token.name.clone().into())
+                        .map(|token_config| token_config.token.clone().into())
                         // Collect into set first to remove duplicates
                         .collect::<HashSet<SemanticTokenType>>()
                         .into_iter()
@@ -261,7 +261,7 @@ pub fn initialize(
                         .semantic_tokens
                         .iter()
                         // Get all modifiers used in token definitions
-                        .flat_map(|token| token.modifiers.clone())
+                        .flat_map(|token_config| token_config.modifiers.clone())
                         // Collect into set first to remove duplicates
                         .collect::<HashSet<SemanticTokenModifier>>()
                         .into_iter()

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -3,6 +3,7 @@ use crate::position::lsp_range_to_kakoune;
 use crate::types::{EditorMeta, EditorParams};
 use crate::util::editor_quote;
 use lsp_types::request::SemanticTokensFullRequest;
+use lsp_types::SemanticTokenModifier;
 use lsp_types::{
     Position, Range, SemanticToken, SemanticTokensOptions, SemanticTokensParams,
     SemanticTokensRegistrationOptions, SemanticTokensResult, SemanticTokensServerCapabilities::*,
@@ -65,18 +66,53 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
                     end: Position::new(line, start + length),
                 };
                 let range = lsp_range_to_kakoune(&range, &document.text, ctx.offset_encoding);
-                let token = &legend.token_types[token_type as usize];
-                (0..32)
+                let token_name = legend.token_types[token_type as usize].as_str();
+                let token_modifiers: Vec<&SemanticTokenModifier> = (0..32)
+                    // Find bits in the mask that equal `1`
                     .filter(|bit| ((token_modifiers_bitset >> bit) & 1u32) == 1u32)
+                    // Map bits to modifiers
                     .map(|bit| &legend.token_modifiers[bit as usize])
-                    .filter_map(|token| ctx.config.semantic_token_modifiers.get(token.as_str()))
-                    .chain(ctx.config.semantic_tokens.get(token.as_str()))
-                    .next()
-                    .map(|face| format!("{}|{}", range, face))
+                    .collect();
+
+                let mut candidates = ctx
+                    .config
+                    .semantic_tokens
+                    .iter()
+                    .filter_map(|token_config| {
+                        if token_name != token_config.name {
+                            return None;
+                        }
+
+                        // All the config's modifiers must exist on the token for this
+                        // config to match.
+                        if !token_config
+                            .modifiers
+                            .iter()
+                            .all(|modifier| token_modifiers.contains(&modifier))
+                        {
+                            return None;
+                        }
+
+                        // But not all the token's modifiers must exist on the config.
+                        // Therefore, we get a count of matching ones and sort by that.
+                        let modifier_count = token_modifiers
+                            .iter()
+                            .filter(|modifier| token_config.modifiers.contains(modifier))
+                            .count();
+
+                        Some((&token_config.face, modifier_count))
+                    })
+                    .collect::<Vec<_>>();
+
+                // Sort by number of matching modifiers, in descending order
+                candidates.sort_by_key(|val| val.1);
+                candidates.reverse();
+                candidates.first().map(|val| format!("{}|{}", range, val.0))
             },
         )
         .collect::<Vec<String>>()
         .join(" ");
+    debug!("ranges: {:?}", &ranges);
     let command = format!(
         "set buffer lsp_semantic_tokens {} {}",
         meta.version, &ranges

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -76,7 +76,7 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
                     .collect();
 
                 let candidates = ctx.config.semantic_tokens.iter().filter(|token_config| {
-                    token_name == token_config.name &&
+                    token_name == token_config.token &&
                         // All the config's modifiers must exist on the token for this
                         // config to match.
                         token_config

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -66,6 +66,8 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
                     end: Position::new(line, start + length),
                 };
                 let range = lsp_range_to_kakoune(&range, &document.text, ctx.offset_encoding);
+                // See the spec for information on the integer encoding:
+                // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_semanticTokens
                 let token_name = legend.token_types[token_type as usize].as_str();
                 let token_modifiers: Vec<&SemanticTokenModifier> = (0..32)
                     // Find bits in the mask that equal `1`

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -112,7 +112,7 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
         )
         .collect::<Vec<String>>()
         .join(" ");
-    debug!("ranges: {:?}", &ranges);
+
     let command = format!(
         "set buffer lsp_semantic_tokens {} {}",
         meta.version, &ranges

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -3,11 +3,10 @@ use crate::position::lsp_range_to_kakoune;
 use crate::types::{EditorMeta, EditorParams};
 use crate::util::editor_quote;
 use lsp_types::request::SemanticTokensFullRequest;
-use lsp_types::SemanticTokenModifier;
 use lsp_types::{
-    Position, Range, SemanticToken, SemanticTokensOptions, SemanticTokensParams,
-    SemanticTokensRegistrationOptions, SemanticTokensResult, SemanticTokensServerCapabilities::*,
-    TextDocumentIdentifier,
+    Position, Range, SemanticToken, SemanticTokenModifier, SemanticTokensOptions,
+    SemanticTokensParams, SemanticTokensRegistrationOptions, SemanticTokensResult,
+    SemanticTokensServerCapabilities::*, TextDocumentIdentifier,
 };
 use url::Url;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use jsonrpc_core::{Call, Output, Params};
-use lsp_types::Range;
+use lsp_types::{Range, SemanticTokenModifier};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
@@ -21,9 +21,7 @@ pub struct Config {
     #[serde(default)]
     pub snippet_support: bool,
     #[serde(default)]
-    pub semantic_tokens: HashMap<String, String>,
-    #[serde(default)]
-    pub semantic_token_modifiers: HashMap<String, String>,
+    pub semantic_tokens: Vec<SemanticTokenConfig>,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -57,6 +55,14 @@ impl Default for ServerConfig {
 
 fn default_offset_encoding() -> OffsetEncoding {
     OffsetEncoding::Utf16
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct SemanticTokenConfig {
+    pub name: String,
+    pub face: String,
+    #[serde(default)]
+    pub modifiers: Vec<SemanticTokenModifier>,
 }
 
 // Editor

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use jsonrpc_core::{Call, Output, Params};
 use lsp_types::{Range, SemanticTokenModifier};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::Error as SerdeError};
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -20,7 +20,7 @@ pub struct Config {
     pub verbosity: u8,
     #[serde(default)]
     pub snippet_support: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_semantic_tokens")]
     pub semantic_tokens: Vec<SemanticTokenConfig>,
 }
 
@@ -63,6 +63,17 @@ pub struct SemanticTokenConfig {
     pub face: String,
     #[serde(default)]
     pub modifiers: Vec<SemanticTokenModifier>,
+}
+
+fn deserialize_semantic_tokens<'de, D>(
+    deserializer: D,
+) -> Result<Vec<SemanticTokenConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::deserialize(deserializer).map_err(|e| {
+        D::Error::custom(e.to_string() + ". See https://github.com/kak-lsp/kak-lsp#semantic-tokens for the new configuration syntax for semantic tokens.")
+    })
 }
 
 // Editor

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,7 +59,7 @@ fn default_offset_encoding() -> OffsetEncoding {
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct SemanticTokenConfig {
-    pub name: String,
+    pub token: String,
     pub face: String,
     #[serde(default)]
     pub modifiers: Vec<SemanticTokenModifier>,


### PR DESCRIPTION
This reworks the semantic highlighting feature to properly utilize modifiers into a feature that matches their name.
Rather than specifying separate face mappings for tokens and modifiers, where the latter overwrite the former, they are consolidated into a single configuration structure.
This allows to map the same token to different faces based on the presence of modifiers.

This does include a breaking change within the configuration file.