### PR TITLE
Fix download version in installation instructions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -23,7 +23,7 @@ brew install kak-lsp/kak-lsp/kak-lsp
 ===== Manual
 
 ----
-curl -O -L https://github.com/kak-lsp/kak-lsp/releases/download/v10.0.0/kak-lsp-v9.0.0-x86_64-apple-darwin.tar.gz
+curl -O -L https://github.com/kak-lsp/kak-lsp/releases/download/v10.0.0/kak-lsp-v10.0.0-x86_64-apple-darwin.tar.gz
 tar xzvf kak-lsp-v10.0.0-x86_64-apple-darwin.tar.gz
 
 # replace `~/.local/bin/` with something on your `$PATH`
@@ -44,7 +44,7 @@ mv kak-lsp.toml ~/.config/kak-lsp/
 ===== Others
 
 ----
-wget https://github.com/kak-lsp/kak-lsp/releases/download/v10.0.0/kak-lsp-v9.0.0-x86_64-unknown-linux-musl.tar.gz
+wget https://github.com/kak-lsp/kak-lsp/releases/download/v10.0.0/kak-lsp-v10.0.0-x86_64-unknown-linux-musl.tar.gz
 tar xzvf kak-lsp-v10.0.0-x86_64-unknown-linux-musl.tar.gz
 
 # replace `~/.local/bin/` with something on your `$PATH`


### PR DESCRIPTION
Looks like the second occurrences of v9 in lines were missed in the search-replace.