### PR TITLE
Provide lsp-show-code-actions, to customize the menu behavior on code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ Breaking changes:
 - `lsp-show-message`, which handles `window/showMessage` requests from the server has been removed. See below for the replacement.
 
 Additions:
-- `lsp-show-message` has been replaced by four separate commands `lsp-show-message-{error,warning,info,log}`
-  The new default commands log the given messages from the language server to the debug buffer. Important messages are shown in `%opt{toolsclient}`.
+- `lsp-show-message` has been replaced by four separate commands `lsp-show-message-{error,warning,info,log}`.
+  The new default implementations log the given messages from the language server to the debug buffer. Important messages are shown in `%opt{toolsclient}`.
+- `lsp-code-actions` use the `menu` command to select an action interactively. The new command `lsp-show-code-actions` can be overridden to customize this behavior (#367).
 
 Bug fixes:
 - Fix renaming of Rust lifetimes (#474).

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -255,6 +255,10 @@ column    = %d
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+define-command -hidden lsp-show-code-actions -params .. -docstring "Present code actions to the user." %{
+    menu %arg{@}
+}
+
 define-command -hidden lsp-execute-command -params 2 -docstring "Execute a command" %{
     declare-option -hidden str lsp_execute_command_command %arg{1}
     declare-option -hidden str lsp_execute_command_arguments %arg{2}

--- a/src/language_features/codeaction.rs
+++ b/src/language_features/codeaction.rs
@@ -66,7 +66,7 @@ pub fn editor_code_actions(
         }
     }
 
-    let menu_args = result
+    let titles_and_commands = result
         .iter()
         .map(|c| match c {
             CodeActionOrCommand::Command(_) => c.clone(),
@@ -97,5 +97,8 @@ pub fn editor_code_actions(
             }
         })
         .join(" ");
-    ctx.exec(meta, format!("menu {}", menu_args));
+    ctx.exec(
+        meta,
+        format!("lsp-show-code-actions {}", titles_and_commands),
+    );
 }


### PR DESCRIPTION
Closes issue #367

For example, this allows to always run "Organize Imports", like so:

	define-command -override -hidden lsp-show-code-actions -params .. %{
	    evaluate-commands %sh{
	        while [ $# -gt 0 ]; do
	            title=$1
	            command=$2
	            shift
	            shift

	            if [ "$title" = "Organize Imports" ]; then
	                printf %s\\n "$command"
	                exit
	            fi
	        done
	    }
	}