### PR TITLE
add default julia setting in kak-lsp.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 - `lsp-show-message`, which handles `window/showMessage` requests from the server has been removed. See below for the replacement.
 
 Additions:
+- Default configuration for Julia (#502).
 - `lsp-show-message` has been replaced by four separate commands `lsp-show-message-{error,warning,info,log}`.
   The new default implementations log the given messages from the language server to the debug buffer. Important messages are shown in `%opt{toolsclient}`.
 - `lsp-code-actions` use the `menu` command to select an action interactively. The new command `lsp-show-code-actions` can be overridden to customize this behavior (#367).

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -184,6 +184,28 @@ roots = ["package.json"]
 command = "json-languageserver"
 args = ["--stdio"]
 
+# Requires Julia packages "LanguageServer", "StaticLint" and "SymbolServer"
+[language.julia]
+filetypes = ["julia"]
+roots = ["Project.toml", ".git"]
+command = "julia"
+args = [
+    "--startup-file=no",
+    "--history-file=no",
+    "-e",
+    """
+        using LanguageServer;
+        using Pkg;
+        import StaticLint;
+        import SymbolServer;
+        import REPL;
+        env_path = dirname(Pkg.Types.Context().env.project_file);
+        server = LanguageServer.LanguageServerInstance(stdin, stdout, env_path, "");
+        server.runlinter = true;
+        run(server);
+    """,
+]
+
 [language.latex]
 filetypes = ["latex"]
 roots = [".git"]


### PR DESCRIPTION
I added default settings for julia support. Requires `LanguageServer, StaticLint, SymbolServer` installed globally in julia. Activates the `project=@.` environment. This means that it searches recursively upwards for a julia Project.toml