### PR TITLE
Mimic VSCode server settings to support workspace/configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Unreleased
 
 Breaking changes:
-- The configuration syntax for `semantic_tokens` has changed. See the updated `kak-lsp.toml` for an example (#488).
+- Two breaking changes to the configuration format - see the updated `kak-lsp.toml` for examples. 
+  - `semantic_tokens` syntax has changed (#488)
+  - `settings` replaces `initialization_options` for server-specific configuration  (#511)
 - Snippet support has been disabled by default, as a workaround for conflicts with Kakoune's built-in completion (#282).
 - `lsp-show-message`, which handles `window/showMessage` requests from the server has been removed. See below for the replacement.
 - Hidden commands `lsp-{next,previous}-match` were removed in favor of `lsp-{next,previous}-location` (#466).
@@ -23,7 +25,7 @@ Bug fixes:
 - Fix responses to `workspace/configuration` in case there are no initialization options set (#509).
 
 Deprecations:
-- `%opt{lsp_server_initialization_options}` and `%opt{lsp_server_configuration}` are deprecated in favor of setting `[language.<filetype>.initialization_options]` in `%opt{lsp_config}`(#500).
+- `%opt{lsp_server_initialization_options}` and `%opt{lsp_server_configuration}` are deprecated in favor of setting `[language.<filetype>.settings]` in `%opt{lsp_config}`(#500).
 - `lsp-{goto,symbols}-{next,previous}-match` are deprecated in favor of `lsp-next-location *goto*` and similar (#466).
 
 ## 10.0.0 - 2021-06-03

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -206,16 +206,8 @@ kak-lsp itself has configuration, but it also adds configuration options to Kako
 
 kak-lsp is configured via a configuration file in https://github.com/toml-lang/toml[TOML] format. By
 default kak-lsp tries to read `kak-lsp/kak-lsp.toml` under OS-specific config dir as described https://docs.rs/dirs/2.0.1/dirs/fn.config_dir.html[here],
-but you can override it with command-line option `--config`.
-
-Look into the default link:kak-lsp.toml[`kak-lsp.toml`], it should be quite self-explanatory.
-For example, here is how to set server-specific configuration:
-
-[source=toml]
-----
-[language.go.initialization_options]
-formatTool = "gofmt"
-----
+but you can override it with command-line option `--config`.  Look into the default
+link:kak-lsp.toml[`kak-lsp.toml`], it should be quite self-explanatory.
 
 *Important*: The configuration file does *not* extend the default configuration, but rather
 overrides it. This means that if you want to customize any of the configuration, you must copy the
@@ -229,31 +221,23 @@ Please let us know if you have any ideas about how to make the default config mo
 
 ==== Server-specific configuration
 
-Many servers accept configuration options that are not part of the LSP spec.
-The TOML table `[language.<filetype>.initialization_options]` can contain arbitrary values They will be sent to the server during server initialization, as well as in `workspace/didChangeConfiguration` whenever you change it via the `lsp_config` option.
-
-If a language server's documentation says it wants a structure like this:
-
-[source=json]
-----
-{
-    "settings": {
-        "rust": {
-            "clippy_preference": "on"
-        }
-    }
-}
-----
-
-+...you can do that in `kak-lsp.toml` or in the `lsp_config` option with an equivalent TOML string:
-
-Be aware of TOML serialization rules: for example, if you want to serialize `{"clippy.preference":"on"}`, use `"clippy.preference" = "on"`.
+Many servers accept configuration options that are not part of the LSP spec.  The TOML table
+`[language.<filetype>.settings]` holds those configuration options.  It has the same structure
+as the corresponding fragments from VSCode's `settings.json`. For example:
 
 [source=toml]
 ----
-[language.rust.initialization_options]
-rust.clippy_preference = "on"
+[language.go]
+...
+settings_section = "gopls"
+[language.go.settings.gopls]
+"formatting.gofumpt" = true
 ----
+
+During server initialization, kak-lsp sends the section specified by `settings_section`; in this
+case `{"formatting.gofumpt":true}`.  Whenever you change the Kakoune option `lsp_config`, the
+same section is sent via `workspace/didChangeConfiguration`.  Additionally, kak-lsp will send
+arbitrary sections that are requested by the server in `workspace/configuration`.
 
 === Configuring Kakoune
 
@@ -268,13 +252,13 @@ kak-lsp's Kakoune integration declares the following options:
 * `lsp_insert_spaces` (bool): When using `lsp-formatting`, if this option is `true`, kak-lsp will ask the language server to indent with spaces rather than tabs.
 * `lsp_auto_highlight_references` (bool): If this option is `true` then `lsp-highlight-references` is executed every time the user pauses in normal mode.
 * `lsp_config` (str): This is a TOML string of the same format as `kak-lsp.toml`, except it only supports one settings:
-** `[language.<filetype>.initialization_options]`: this works just like the static configuration of the same name in `kak-lsp.toml`, see the server-specific configuration section. This will override the static configuration of the given language.
+** `[language.<filetype>.settings]`: this works just like the static configuration of the same name in `kak-lsp.toml`, see the section about server-specific configuration. This will override the static configuration of the given language.
 
 For example, you can toggle an option dynamically with a command like this:
 
 ----
 set-option global lsp_config %{
-    [language.go.initialization_options]
+    [language.go.settings.gopls]
     "formatting.gofumpt" = true
 }
 ----

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -58,14 +58,19 @@ args = ["-c", "dart $(dirname $(command -v dart))/snapshots/analysis_server.dart
 filetypes = ["elixir"]
 roots = ["mix.exs"]
 command = "elixir-ls"
+settings_section = "elixirLS"
+[language.elixir.settings.elixirLS]
+# See https://github.com/elixir-lsp/elixir-ls/blob/master/apps/language_server/lib/language_server/server.ex
+# dialyzerEnable = true
 
 [language.elm]
 filetypes = ["elm"]
 roots = ["elm.json"]
 command = "elm-language-server"
 args = ["--stdio"]
-
-[language.elm.initialization_options]
+settings_section = "elmLS"
+[language.elm.settings.elmLS]
+# See https://github.com/elm-tooling/elm-language-server#server-settings
 runtime = "node"
 elmPath = "elm"
 elmFormatPath = "elm-format"
@@ -76,12 +81,20 @@ filetypes = ["go"]
 roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
 command = "gopls"
 offset_encoding = "utf-8"
+settings_section = "gopls"
+[language.go.settings.gopls]
+# See https://github.com/golang/tools/blob/master/gopls/doc/settings.md
+# "build.buildFlags" = []
 
 [language.haskell]
 filetypes = ["haskell"]
 roots = ["Setup.hs", "stack.yaml", "*.cabal"]
 command = "haskell-language-server-wrapper"
 args = ["--lsp"]
+settings_section = "haskell"
+[language.haskell.settings.haskell]
+# See https://github.com/latex-lsp/texlab/blob/e1ee8495b0f54b4411a1ffacf787efa621d8f826/src/options.rs
+# formattingProvider = "ormolu"
 
 [language.html]
 filetypes = ["html"]
@@ -115,6 +128,9 @@ args = ["--stdio"]
 #     "-data",
 #     "/path/to/eclipse-workspace",
 # ]
+# [language.java.settings]
+# # See https://github.dev/eclipse/eclipse.jdt.ls
+# # "java.format.insertSpaces" = true
 
 [language.javascript]
 filetypes = ["javascript"]
@@ -149,16 +165,31 @@ args = [
         run(server);
     """,
 ]
+[language.julia.settings]
+# See https://github.com/julia-vscode/LanguageServer.jl/blob/master/src/requests/workspace.jl
+# Format options. See https://github.com/julia-vscode/DocumentFormat.jl/blob/master/src/DocumentFormat.jl
+# "julia.format.indent" = 4
+# Lint options. See https://github.com/julia-vscode/StaticLint.jl/blob/master/src/linting/checks.jl
+# "julia.lint.call" = true
+# Other options, see https://github.com/julia-vscode/LanguageServer.jl/blob/master/src/requests/workspace.jl
+# "julia.lint.run" = "true"
 
 [language.latex]
 filetypes = ["latex"]
 roots = [".git"]
 command = "texlab"
+settings_section = "texlab"
+[language.latex.settings.texlab]
+# See https://github.com/latex-lsp/texlab/blob/master/src/options.rs
+# bibtexFormatter = "texlab"
 
 [language.lua]
 filetypes = ["lua"]
 roots = [".git"]
 command = "lua-language-server"
+[language.lua.settings]
+# See https://github.com/sumneko/vscode-lua/blob/master/setting/schema.json
+# "Lua.diagnostics.enable" = true
 
 [language.nim]
 filetypes = ["nim"]
@@ -180,15 +211,19 @@ filetypes = ["php"]
 roots = [".htaccess", "composer.json"]
 command = "intelephense"
 args = ["--stdio"]
-
-[language.php.initialization_options]
-storagePath = "/tmp/intelephense"
+settings_section = "intelephense"
+[language.php.settings]
+intelephense.storagePath = "/tmp/intelephense"
 
 [language.python]
 filetypes = ["python"]
 roots = ["requirements.txt", "setup.py", ".git", ".hg"]
 command = "pyls"
 offset_encoding = "utf-8"
+[language.python.settings]
+# See https://github.com/palantir/python-language-server#configuration
+# and https://github.com/palantir/python-language-server/blob/develop/vscode-client/package.json
+# "pyls.configurationSources" = ["flake8"]
 
 [language.reason]
 filetypes = ["reason"]
@@ -200,6 +235,9 @@ filetypes = ["ruby"]
 roots = ["Gemfile"]
 command = "solargraph"
 args = ["stdio"]
+[language.ruby.settings]
+# See https://github.com/castwide/solargraph/blob/master/lib/solargraph/language_server/host.rb
+# "solargraph.completion" = true
 
 [language.rust]
 filetypes = ["rust"]
@@ -215,6 +253,9 @@ args = [
         fi
     """,
 ]
+[language.rust.settings.rust]
+# See https://github.com/rust-lang/rls#configuration
+# features = []
 
 # [language.rust]
 # filetypes = ["rust"]
@@ -230,7 +271,11 @@ args = [
 #         fi
 #     """,
 # ]
-# [language.rust.initialization_options]
+# settings_section = "rust-analyzer"
+# [language.rust.settings.rust-analyzer]
+# hoverActions.enable = false # kak-lsp doesn't support this at the moment
+# # cargo.features = []
+# # See https://rust-analyzer.github.io/manual.html#configuration
 # # If you get 'unresolved proc macro' warnings, you have two options
 # # 1. The safe choice is two disable the warning:
 # diagnostics.disabled = ["unresolved-proc-macro"]
@@ -244,12 +289,19 @@ filetypes = ["terraform"]
 roots = ["*.tf"]
 command = "terraform-ls"
 args = ["serve"]
+[language.terraform.settings.terraform-ls]
+# See https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md
+# rootModulePaths = []
 
 [language.yaml]
 filetypes = ["yaml"]
 roots = [".git"]
 command = "yaml-language-server"
 args = ["--stdio"]
+[language.yaml.settings]
+# See https://github.com/redhat-developer/yaml-language-server#language-server-settings
+# Defaults are at https://github.com/redhat-developer/yaml-language-server/blob/master/src/yamlSettings.ts
+# yaml.format.enable = true
 
 [language.zig]
 filetypes = ["zig"]

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -46,11 +46,11 @@ declare-option -docstring "Automatically highlight references with Reference fac
 declare-option -docstring "Set it to a positive number to limit the size of the lsp hover output" int lsp_hover_max_lines 0
 
 declare-option -docstring "Dynamic TOML configuration string. Currently supports
-- [language.<filetype>.initialization_options]
+- [language.<filetype>.settings]
 " str lsp_config
 # Highlight TOML keys in kakrc if they are supported by dynamic configuration.
 try %{
-    add-highlighter shared/kakrc/code/lsp_keywords regex \[(language\.[a-z_]+\.initialization_options)\] 1:title
+    add-highlighter shared/kakrc/code/lsp_keywords regex \[(language\.[a-z_]+\.settings(?:\.[^\]])?)\] 1:title
 }
 declare-option -docstring "DEPRECATED, use %opt{lsp_config}. Configuration to send in workspace/didChangeConfiguration messages" str-to-str-map lsp_server_configuration
 declare-option -docstring "DEPRECATED, use %opt{lsp_config}. Configuration to send in initializationOptions of Initialize messages." str-to-str-map lsp_server_initialization_options

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,14 +45,15 @@ pub struct LanguageConfig {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
-    pub initialization_options: Option<Value>,
+    pub settings_section: Option<String>,
+    pub settings: Option<Value>,
     #[serde(default = "default_offset_encoding")]
     pub offset_encoding: OffsetEncoding,
 }
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct DynamicLanguageConfig {
-    pub initialization_options: Option<Value>,
+    pub settings: Option<Value>,
 }
 
 impl Default for ServerConfig {

--- a/test/gopls-dynamic-settings.sh
+++ b/test/gopls-dynamic-settings.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# REQUIRES: command -v gopls
+
+. test/lib.sh
+
+cat > main.go << EOF
+package main
+
+func format_me() {
+	println("spurious blank line")
+
+}
+EOF
+
+session=session
+$tmux new-session -d -x 80 -y 7 kak -s "$session" -e "$kak_startup_commands; lsp-enable" main.go
+$tmux resize-window -x 80 -y 7 ||: # Workaround for macOS.
+sleep "$jiffy"
+
+$tmux send-keys h,lf
+sleep "$jiffy"
+
+$tmux capture-pane -p
+# CHECK: package main
+# CHECK:
+# CHECK: func format_me() {
+# CHECK: 	println("spurious blank line")
+# CHECK:
+# CHECK: }
+# CHECK:
+# CHECK: main.go 1:1  1 sel - client0@[session]
+
+echo '
+set global lsp_config %{
+	[language.go.settings.gopls]
+	"formatting.gofumpt" = true
+}' | kak -p $session
+sleep "$jiffy"
+
+$tmux send-keys ,lf # :lsp-formatting
+sleep "$jiffy"
+
+$tmux capture-pane -p
+# CHECK: package main
+# CHECK:
+# CHECK: func format_me() {
+# CHECK: 	println("spurious blank line")
+# CHECK: }
+# CHECK: ~
+# CHECK: main.go 1:1 [+] 1 sel - client0@[session]


### PR DESCRIPTION
"settings" replaces "initialization_options".
It can be set in kak-lsp.toml, or dynamically in %opt{lsp_config}.

"settings" uses the same structure as VSCode's settings.json. This
means we can properly implement workspace/configuration.

Initialization options and parameters for didChangeConfiguration are
computed by looking up a server-specific section. This seems to match
the expected behavior for all language servers I tried.

Includes configuration for all default language servers (largely
untested). These are default configurations according to the servers'
documentation. I'm not sure how to handle these in future;
- leaving them uncommented has the upside that we'll quickly find errors
- however, the downside is that we shadow the server's actual default
  configuration
- additionally these lists might go out of date quickly

I'm leaning towards only including (commented) example settings
for most servers. Users will get an idea of how it works and can
consult server docs for all available settings.
Perhaps we can include uncommented default settings for "important"
servers.

TODO maybe keep initialization_options around for one release cycle?

Closes #234, #507