### PR TITLE
Implement Markdown parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +337,7 @@ dependencies = [
  "jsonrpc-core",
  "libc",
  "lsp-types",
+ "pulldown-cmark",
  "rand",
  "regex",
  "ropey",
@@ -465,6 +475,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -821,6 +843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +899,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ sloggers = "1.0.1"
 toml = "0.5.6"
 url = { version = "2.1.1", features = ["serde"] }
 whoami = "0.8.2"
+pulldown-cmark = "0.8.0"
 
 [profile.release]
 lto = true

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -373,7 +373,7 @@ kak-lsp supports showing diagnostics inline after their respective line, but thi
 lsp-inlay-diagnostics-enable global
 ----
 
-== Markdown parsing
+== Markdown rendering in info box
 
 kak-lsp offers multiple ways to show additional information provided by the language server, such as documentation for the token under the cursor or documentation for completion candidates. The Language Server Protocol allows for both plain text and Markdown in these scenarios, and most servers do implement Markdown.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -389,11 +389,20 @@ To ensure compatiblity, these faces are, by default, undefined and fall back to 
 | The default text color. You'll likely want to set this to `Information`, the default face for text in the info box.
 Leaving it blank has the same effect.
 
+| `InfoBlock`
+| The face used for code blocks. Language specific syntax highlighting for code blocks is not possible.
+
+| `InfoBlockQuote`
+| The face used for block quotes. The `>` Markdown syntax is still rendered.
+
+| `InfoBullet`
+| The face used to highlight the list symbol for both ordered and unordered lists. For the list item's text `InfoDefault` is used.
+
+| `InfoHeader`
+| The face used for headings. There is currently no distinction between different heading levels.
+
 | `InfoLink`
 | The face used to highlight link titles. Maybe some classic `blue+u` for this one?
-
-| `InfoMono`
-| The face used for inline monospace blocks, i.e. inline code.
 
 | `InfoLinkMono`
 | This face is assigned to inline code within link titles, such as in the following Markdown snippet. Here `format` would receive the `InfoLinkMono` face.
@@ -402,32 +411,23 @@ Leaving it blank has the same effect.
 [the `format` function](https://example.com)
 ----
 
-| `InfoBlock`
-| The face used for code blocks. Language specific syntax highlighting for code blocks is not possible.
-
-| `InfoBullet`
-| The face used to highlight the list symbol for both ordered and unordered lists. For the list item's text `InfoDefault` is used.
-
-| `InfoHeader`
-| The face used for headings. There is currently no distinction between different heading levels.
+| `InfoMono`
+| The face used for inline monospace blocks, i.e. inline code.
 
 | `InfoRule`
 | The face used for horizontal lines (rules).
 
-| `InfoQuote`
-| The face used for block quotes. The `>` Markdown syntax is still rendered.
-
 | `InfoDiagnosticError`
 | Used for error messages in the diagnostics hover info. This defaults to Kakoune's built-in `Error` face.
 
-| `InfoDiagnosticWarning`
-| Used for warning messages in the diagnostics hover info.
+| `InfoDiagnosticHint`
+| Used for hints in the diagnostics hover info.
 
 | `InfoDiagnosticInformation`
 | Used for informational messages in the diagnostics hover info.
 
-| `InfoDiagnosticHint`
-| Used for hints in the diagnostics hover info.
+| `InfoDiagnosticWarning`
+| Used for warning messages in the diagnostics hover info.
 
 |===
 
@@ -435,18 +435,18 @@ For convenience, here is a snippet to paste into your theme/config:
 
 ----
 face global InfoDefault               Information
-face global InfoHeader                Information
 face global InfoBlock                 Information
+face global InfoBlockQuote            Information
 face global InfoBullet                Information
+face global InfoHeader                Information
 face global InfoLink                  Information
-face global InfoMono                  Information
 face global InfoLinkMono              Information
+face global InfoMono                  Information
 face global InfoRule                  Information
-face global InfoQuote                 Information
+face global InfoDiagnosticError       Error
 face global InfoDiagnosticHint        Information
 face global InfoDiagnosticInformation Information
 face global InfoDiagnosticWarning     Information
-face global InfoDiagnosticError       Error
 ----
 
 Limitations of this feature are:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -373,6 +373,67 @@ kak-lsp supports showing diagnostics inline after their respective line, but thi
 lsp-inlay-diagnostics-enable global
 ----
 
+== Markdown parsing
+
+kak-lsp offers multiple ways to show additional information provided by the language server, such as documentation for the token under the cursor or documentation for completion candidates. The Language Server Protocol allows for both plain text and Markdown in these scenarios, and most servers do implement Markdown.
+
+To utilize that, kak-lsp parses the Markdown into Kakoune's markup language, utilizing various faces for styling.
+
+To ensure compatiblity, these faces are, by default, undefined and fall back to whatever the regular styling is in the environment they are used (such as the `Information` face in an `info` box). To enable Markdown highlighting, define the following faces in your theme or `kakrc`:
+
+[cols="1a,3a"]
+|===
+| Face | Usage
+
+| `InfoDefault`
+| The default text color. You'll likely want to set this to `Information`, the default face for text in the info box.
+Leaving it blank has the same effect.
+
+| `InfoLink`
+| The face used to highlight link titles. Maybe some classic `blue+u` for this one?
+
+| `InfoMono`
+| The face used for inline monospace blocks, i.e. inline code.
+
+| `InfoLinkMono`
+| This face is assigned to inline code within link titles, such as in the following Markdown snippet. Here `format` would receive the `InfoLinkMono` face.
+
+----
+[the `format` function](https://example.com)
+----
+
+| `InfoBlock`
+| The face used for code blocks. Language specific syntax highlighting for code blocks is not possible.
+
+| `InfoBullet`
+| The face used to highlight the list symbol for both ordered and unordered lists. For the list item's text `InfoDefault` is used.
+
+| `InfoHeader`
+| The face used for headings. There is currently no distinction between different heading levels.
+
+| `InfoRule`
+| The face used for horizontal lines (rules).
+
+| `InfoDiagnosticError`
+| Used for error messages in the diagnostics hover info. This defaults to Kakoune's built-in `Error` face.
+
+| `InfoDiagnosticWarning`
+| Used for warning messages in the diagnostics hover info.
+
+| `InfoDiagnosticInformation`
+| Used for informational messages in the diagnostics hover info.
+
+| `InfoDiagnosticHint`
+| Used for hints in the diagnostics hover info.
+
+|===
+
+Limitations of this feature are:
+
+* Language specific syntax highlighting for code blocks is not possible.
+* For hyperlinks, only their title (the pretty name) is shown.
+* The original syntax for headings is retained to visualize their level.
+
 == Snippets
 
 kak-lsp has experimental support for snippets. It is enabled by setting `snippet_support = true` at the top level of the config.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -414,6 +414,9 @@ Leaving it blank has the same effect.
 | `InfoRule`
 | The face used for horizontal lines (rules).
 
+| `InfoQuote`
+| The face used for block quotes. The `>` Markdown syntax is still rendered.
+
 | `InfoDiagnosticError`
 | Used for error messages in the diagnostics hover info. This defaults to Kakoune's built-in `Error` face.
 
@@ -427,6 +430,24 @@ Leaving it blank has the same effect.
 | Used for hints in the diagnostics hover info.
 
 |===
+
+For convenience, here is a snippet to paste into your theme/config:
+
+----
+face global InfoDefault               Information
+face global InfoHeader                Information
+face global InfoBlock                 Information
+face global InfoBullet                Information
+face global InfoLink                  Information
+face global InfoMono                  Information
+face global InfoLinkMono              Information
+face global InfoRule                  Information
+face global InfoQuote                 Information
+face global InfoDiagnosticHint        Information
+face global InfoDiagnosticInformation Information
+face global InfoDiagnosticWarning     Information
+face global InfoDiagnosticError       Error
+----
 
 Limitations of this feature are:
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -973,15 +973,19 @@ define-command -hidden lsp-show-hover -params 3 -docstring %{
 } %{ evaluate-commands %sh{
     lsp_info=$2
     lsp_diagnostics=$3
+
+    # To make sure we always show diagnostics, restrict only the info portion based
+    # on the configured maximum line count
+    if [ $kak_opt_lsp_hover_max_lines -gt 0 ]; then
+        diagnostics_count=$(printf "%s", "$lsp_diagnostics" | wc -l)
+        lsp_info=$(printf %s "$lsp_info" | head -n $(($kak_opt_lsp_hover_max_lines - 2 - $diagnostics_count)))
+    fi
+
     content=$(eval "${kak_opt_lsp_show_hover_format}")
     # remove leading whitespace characters
     content="${content#"${content%%[![:space:]]*}"}"
     # remove trailing whitespace characters
     content="${content%"${content##*[![:space:]]}"}"
-
-    if [ $kak_opt_lsp_hover_max_lines -gt 0 ]; then
-        content=$(printf %s "$content" | head -n $kak_opt_lsp_hover_max_lines)
-    fi
 
     content=$(printf %s "$content" | sed s/\'/\'\'/g)
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -71,13 +71,13 @@ declare-option -docstring "Character to signal a warning in the gutter" str lsp_
 # show up in the info box.
 declare-option -docstring "Format hover info" str lsp_show_hover_format '
 if [ -n "${lsp_info}" ]; then
-    printf "{+b}Info:{default}\n%s" "${lsp_info}"
+    printf "{InfoDefault+b}Info:{InfoDefault}\n%s" "${lsp_info}"
 fi
 if [ -n "${lsp_info}${lsp_diagnostics}" ]; then
     printf "\n\n"
 fi
 if [ -n "${lsp_diagnostics}" ]; then
-    printf "{+b}Diagnostics:{default}\n%s" "${lsp_diagnostics}"
+    printf "{InfoDefault+b}Diagnostics:{InfoDefault}\n%s" "${lsp_diagnostics}"
 fi'
 # If you want to see only hover info, try 
 # set-option global lsp_show_hover_format 'printf %s "${lsp_info}"'
@@ -110,6 +110,25 @@ declare-option -hidden range-specs lsp_semantic_tokens
 declare-option -hidden range-specs rust_analyzer_inlay_hints
 declare-option -hidden range-specs lsp_diagnostics
 declare-option -hidden str lsp_project_root
+
+# Faces used for Markdown highlighting in the info box
+# We can't assume the user's theme and any best effort attempts
+# for picking colors will likely not work for many users.
+# Therefore, by default, most are not defined until the user does so
+# explicitly.
+# set-face global InfoDefault Information
+# set-face global InfoHeader Information
+# set-face global InfoBlock Information
+# set-face global InfoBullet Information
+# set-face global InfoLink Information
+# set-face global InfoMono Information
+# set-face global InfoLinkMono Information
+# set-face global InfoRule Information
+# set-face global InfoDiagnosticHint Information
+# set-face global InfoDiagnosticInformation Information
+# set-face global InfoDiagnosticWarning Information
+set-face global InfoDiagnosticError Error
+
 
 ### Requests ###
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -953,8 +953,8 @@ define-command -hidden lsp-show-hover -params 3 -docstring %{
     content=$(printf %s "$content" | sed s/\'/\'\'/g)
 
     case $kak_opt_lsp_hover_anchor in
-        true) printf "info -anchor %%arg{1} -- '%s'" "$content";;
-        *)    printf "info -- '%s'" "$content";;
+        true) printf "info -markup -anchor %%arg{1} -- '%s'" "$content";;
+        *)    printf "info -markup -- '%s'" "$content";;
     esac
 }}
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -106,25 +106,6 @@ declare-option -hidden range-specs rust_analyzer_inlay_hints
 declare-option -hidden range-specs lsp_diagnostics
 declare-option -hidden str lsp_project_root
 
-# Faces used for Markdown highlighting in the info box
-# We can't assume the user's theme and any best effort attempts
-# for picking colors will likely not work for many users.
-# Therefore, by default, most are not defined until the user does so
-# explicitly.
-# set-face global InfoDefault Information
-# set-face global InfoHeader Information
-# set-face global InfoBlock Information
-# set-face global InfoBullet Information
-# set-face global InfoLink Information
-# set-face global InfoMono Information
-# set-face global InfoLinkMono Information
-# set-face global InfoRule Information
-# set-face global InfoQuote Information
-# set-face global InfoDiagnosticHint Information
-# set-face global InfoDiagnosticInformation Information
-# set-face global InfoDiagnosticWarning Information
-set-face global InfoDiagnosticError Error
-
 
 ### Requests ###
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -70,14 +70,9 @@ declare-option -docstring "Character to signal a warning in the gutter" str lsp_
 # The string is `eval`ed to produce the content to display, so anything send to stdout will
 # show up in the info box.
 declare-option -docstring "Format hover info" str lsp_show_hover_format '
-if [ -n "${lsp_info}" ]; then
-    printf "{InfoDefault+b}Info:{InfoDefault}\n%s" "${lsp_info}"
-fi
-if [ -n "${lsp_info}${lsp_diagnostics}" ]; then
-    printf "\n\n"
-fi
+printf "%s\n\n" "${lsp_info}"
 if [ -n "${lsp_diagnostics}" ]; then
-    printf "{InfoDefault+b}Diagnostics:{InfoDefault}\n%s" "${lsp_diagnostics}"
+    printf "{+b@InfoDefault}Diagnostics:{InfoDefault}\n%s" "${lsp_diagnostics}"
 fi'
 # If you want to see only hover info, try 
 # set-option global lsp_show_hover_format 'printf %s "${lsp_info}"'

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -124,6 +124,7 @@ declare-option -hidden str lsp_project_root
 # set-face global InfoMono Information
 # set-face global InfoLinkMono Information
 # set-face global InfoRule Information
+# set-face global InfoQuote Information
 # set-face global InfoDiagnosticHint Information
 # set-face global InfoDiagnosticInformation Information
 # set-face global InfoDiagnosticWarning Information

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -955,9 +955,9 @@ define-command -hidden lsp-show-hover -params 3 -docstring %{
     lsp_diagnostics=$3
     content=$(eval "${kak_opt_lsp_show_hover_format}")
     # remove leading whitespace characters
-    content="${content##[[:space:]]}"
+    content="${content#"${content%%[![:space:]]*}"}"
     # remove trailing whitespace characters
-    content="${content%%[[:space:]]}"
+    content="${content%"${content##*[![:space:]]}"}"
 
     if [ $kak_opt_lsp_hover_max_lines -gt 0 ]; then
         content=$(printf %s "$content" | head -n $kak_opt_lsp_hover_max_lines)

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -74,7 +74,7 @@ if [ -n "${lsp_info}" ]; then
     printf "{+b}Info:{default}\n%s" "${lsp_info}"
 fi
 if [ -n "${lsp_info}${lsp_diagnostics}" ]; then
-    printf "\n"
+    printf "\n\n"
 fi
 if [ -n "${lsp_diagnostics}" ]; then
     printf "{+b}Diagnostics:{default}\n%s" "${lsp_diagnostics}"

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -64,11 +64,24 @@ declare-option -docstring "Character to signal a warning in the gutter" str lsp_
 # Another good default:
 # set-option global lsp_diagnostic_line_error_sign '▓'
 # set-option global lsp_diagnostic_line_warning_sign '▒'
-# This is used to render lsp-hover response.
-# By default it shows both hover info and diagnostics.
-declare-option -docstring "Format hover info" str lsp_show_hover_format 'printf ''%s\n\n%s'' "${lsp_info}" "${lsp_diagnostics}"'
+
+# This is used to render lsp-hover responses.
+# By default it checks both hover info and diagnostics and shows them when defined.
+# The string is `eval`ed to produce the content to display, so anything send to stdout will
+# show up in the info box.
+declare-option -docstring "Format hover info" str lsp_show_hover_format '
+if [ -n "${lsp_info}" ]; then
+    printf "{+b}Info:{default}\n%s" "${lsp_info}"
+fi
+if [ -n "${lsp_info}${lsp_diagnostics}" ]; then
+    printf "\n"
+fi
+if [ -n "${lsp_diagnostics}" ]; then
+    printf "{+b}Diagnostics:{default}\n%s" "${lsp_diagnostics}"
+fi'
 # If you want to see only hover info, try 
 # set-option global lsp_show_hover_format 'printf %s "${lsp_info}"'
+
 declare-option -docstring %{Defines location patterns for lsp-next-location and lsp-previous-location.
 Default locations look like "file:line[:column][:message]"
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -942,9 +942,9 @@ define-command -hidden lsp-show-hover -params 3 -docstring %{
     lsp_diagnostics=$3
     content=$(eval "${kak_opt_lsp_show_hover_format}")
     # remove leading whitespace characters
-    content="${content#"${content%%[![:space:]]*}"}"
+    content="${content##[[:space:]]}"
     # remove trailing whitespace characters
-    content="${content%"${content##*[![:space:]]}"}"
+    content="${content%%[[:space:]]}"
 
     if [ $kak_opt_lsp_hover_max_lines -gt 0 ]; then
         content=$(printf %s "$content" | head -n $kak_opt_lsp_hover_max_lines)

--- a/src/general.rs
+++ b/src/general.rs
@@ -93,8 +93,8 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                         snippet_support: Some(ctx.config.snippet_support),
                         commit_characters_support: Some(false),
                         documentation_format: Some(vec![
-                            MarkupKind::PlainText,
                             MarkupKind::Markdown,
+                            MarkupKind::PlainText,
                         ]),
                         deprecated_support: Some(false),
                         preselect_support: Some(false),
@@ -138,7 +138,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 }),
                 hover: Some(HoverClientCapabilities {
                     dynamic_registration: Some(false),
-                    content_format: Some(vec![MarkupKind::PlainText, MarkupKind::Markdown]),
+                    content_format: Some(vec![MarkupKind::Markdown, MarkupKind::PlainText]),
                 }),
                 signature_help: Some(SignatureHelpClientCapabilities {
                     dynamic_registration: Some(false),

--- a/src/general.rs
+++ b/src/general.rs
@@ -92,7 +92,10 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                     completion_item: Some(CompletionItemCapability {
                         snippet_support: Some(ctx.config.snippet_support),
                         commit_characters_support: Some(false),
-                        documentation_format: Some(vec![MarkupKind::PlainText]),
+                        documentation_format: Some(vec![
+                            MarkupKind::PlainText,
+                            MarkupKind::Markdown,
+                        ]),
                         deprecated_support: Some(false),
                         preselect_support: Some(false),
                         tag_support: None,

--- a/src/general.rs
+++ b/src/general.rs
@@ -135,7 +135,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 }),
                 hover: Some(HoverClientCapabilities {
                     dynamic_registration: Some(false),
-                    content_format: Some(vec![MarkupKind::PlainText]),
+                    content_format: Some(vec![MarkupKind::PlainText, MarkupKind::Markdown]),
                 }),
                 signature_help: Some(SignatureHelpClientCapabilities {
                     dynamic_registration: Some(false),
@@ -272,7 +272,14 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 show_message: None,
                 show_document: None,
             }),
-            general: None,
+            general: Some(GeneralClientCapabilities {
+                regular_expressions: None,
+                markdown: Some(MarkdownClientCapabilities {
+                    parser: String::from("kak-lsp"),
+                    version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+                }),
+                stale_request_support: None,
+            }),
             offset_encoding: Some(vec![match ctx.offset_encoding {
                 OffsetEncoding::Utf8 => "utf-8".to_string(),
                 OffsetEncoding::Utf16 => "utf-16".to_string(),

--- a/src/general.rs
+++ b/src/general.rs
@@ -275,7 +275,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
             general: Some(GeneralClientCapabilities {
                 regular_expressions: None,
                 markdown: Some(MarkdownClientCapabilities {
-                    parser: String::from("kak-lsp"),
+                    parser: "kak-lsp".to_string(),
                     version: Some(env!("CARGO_PKG_VERSION").to_owned()),
                 }),
                 stale_request_support: None,

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -68,7 +68,7 @@ pub fn editor_completion(
                     markdown.push_str(&detail);
 
                     if doc.is_some() {
-                        markdown.push_str("\n---\n");
+                        markdown.push_str("\n\n---\n\n");
                     }
                 }
 

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -40,7 +40,6 @@ pub fn editor_completion(
         CompletionResponse::Array(items) => items,
         CompletionResponse::List(list) => list.items,
     };
-    let unescape_markdown_re = Regex::new(r"\\(?P<c>.)").unwrap();
     let maxlen = items.iter().map(|x| x.label.len()).max().unwrap_or(0);
     let escape_bar = |s: &str| s.replace("|", r"\|");
     let snippet_prefix_re = Regex::new(r"^[^\[\(<\n\$]+").unwrap();
@@ -48,27 +47,47 @@ pub fn editor_completion(
     let items = items
         .into_iter()
         .map(|x| {
-            let mut doc = x.documentation.map(|doc| {
-                match doc {
+            let doc = x.documentation.map(|doc| {
+                let value = match doc {
                     Documentation::String(st) => st,
-                    Documentation::MarkupContent(mup) => match mup.kind {
-                        MarkupKind::PlainText => mup.value,
-                        // NOTE just in case server ignored our documentationFormat capability
-                        // we want to unescape markdown to make text a bit more readable
-                        MarkupKind::Markdown => unescape_markdown_re
-                            .replace_all(&mup.value, r"$c")
-                            .to_string(),
-                    },
-                }
+                    Documentation::MarkupContent(content) => content.value,
+                };
+
+                value
             });
 
-            if let Some(detail) = x.detail {
-                doc = doc.map(|doc| format!("{}\n\n{}", detail, doc));
-            }
+            // Combine the 'detail' line and the full-text documentation into
+            // a single string. If both exist, separate them with a horizontal rule.
+            let markdown = {
+                let mut markdown = String::new();
 
-            let doc = doc
-                .map(|doc| format!("info -style menu -- %§{}§", doc.replace("§", "\\§")))
-                .unwrap_or_else(|| String::from("nop"));
+                if let Some(detail) = x.detail {
+                    markdown.push_str(&detail);
+
+                    if doc.is_some() {
+                        markdown.push_str("\n---\n");
+                    }
+                }
+
+                if let Some(doc) = doc {
+                    markdown.push_str(&doc);
+                }
+
+                markdown
+            };
+
+            let doc = if !markdown.is_empty() {
+                let markup = markdown_to_kakoune_markup(markdown);
+                format!(
+                    "info -markup -style menu -- %§{}§",
+                    markup.replace("§", "\\§")
+                )
+            } else {
+                // When the user scrolls through the list of completion candidates, Kakoune
+                // does not clean up the info box. We need to do that explicitly, in this case by
+                // requesting an empty one.
+                "info -style menu ''".to_string()
+            };
 
             let mut entry = x.label.clone();
             if let Some(k) = x.kind {

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -53,20 +53,22 @@ pub fn editor_hover(
                     let face = x
                         .severity
                         .map(|sev| match sev {
-                            DiagnosticSeverity::Error => "{InfoDiagnosticError}",
-                            DiagnosticSeverity::Warning => "{InfoDiagnosticWarning}",
-                            DiagnosticSeverity::Information => "{InfoDiagnosticInformation}",
-                            DiagnosticSeverity::Hint => "{InfoDiagnosticHint}",
+                            DiagnosticSeverity::Error => FACE_DIAGNOSTIC_ERROR,
+                            DiagnosticSeverity::Warning => FACE_DIAGNOSTIC_WARNING,
+                            DiagnosticSeverity::Information => FACE_DIAGNOSTIC_INFO,
+                            DiagnosticSeverity::Hint => FACE_DIAGNOSTIC_HINT,
                         })
-                        .unwrap_or_else(|| "");
+                        .unwrap_or(FACE_DEFAULT);
 
                     if !x.message.is_empty() {
-                        // Append `{default}` face to prevent bleeding over into the next entry
+                        // Append FACE_DEFAULT to prevent bleeding over into the next entry
                         Some(format!(
-                            "• {}{}{{default}}",
+                            "• {{{}}}{}{{{}}}",
                             face,
                             // Indent line breaks to the same level as the bullet point
-                            x.message.replace("\n", "\n  ")
+                            // and escape for Kakoune's markup syntax.
+                            escape_brace(&x.message.replace("\n", "\n  ")),
+                            FACE_DEFAULT
                         ))
                     } else {
                         None

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -5,7 +5,6 @@ use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
 use serde::Deserialize;
-use std::str;
 use url::Url;
 
 pub fn text_document_hover(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -50,7 +50,6 @@ pub fn editor_hover(
                             && pos.character <= end.character)
                 })
                 .filter_map(|x| {
-                    let message = markdown_to_kakoune_markup(&x.message);
                     let face = x
                         .severity
                         .map(|sev| match sev {
@@ -61,9 +60,14 @@ pub fn editor_hover(
                         })
                         .unwrap_or_else(|| "");
 
-                    if !message.is_empty() {
+                    if !x.message.is_empty() {
                         // Append `{default}` face to prevent bleeding over into the next entry
-                        Some(format!("{}• {}{{default}}", face, message))
+                        Some(format!(
+                            "• {}{}{{default}}",
+                            face,
+                            // Indent line breaks to the same level as the bullet point
+                            x.message.replace("\n", "\n  ")
+                        ))
                     } else {
                         None
                     }

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -79,25 +79,13 @@ pub fn editor_hover(
     let contents = match result {
         None => "".to_string(),
         Some(result) => match result.contents {
-            HoverContents::Scalar(contents) => {
-                let markdown = match contents {
-                    MarkedString::String(s) => s,
-                    MarkedString::LanguageString(s) => format!("```\n{}\n```", s.value),
-                };
-                markdown_to_kakoune_markup(markdown)
-            }
+            HoverContents::Scalar(contents) => parse_marked_string(contents),
             HoverContents::Array(contents) => contents
                 .into_iter()
-                .filter_map(|marked| {
-                    let markdown = match marked {
-                        MarkedString::String(s) => s,
-                        MarkedString::LanguageString(s) => format!("```\n{}\n```", s.value),
-                    };
-                    let markup = markdown_to_kakoune_markup(markdown);
-
+                .map(parse_marked_string)
+                .filter_map(|markup| {
                     if !markup.is_empty() {
-                        // Append `{default}` face to prevent bleeding over into the next entry
-                        Some(format!("• {}{{default}}", markup))
+                        Some(format!("• {}", markup))
                     } else {
                         None
                     }

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -53,10 +53,10 @@ pub fn editor_hover(
                     let face = x
                         .severity
                         .map(|sev| match sev {
-                            DiagnosticSeverity::Error => "{DiagnosticError}",
-                            DiagnosticSeverity::Warning => "{DiagnosticWarning}",
-                            DiagnosticSeverity::Information => "{Information}",
-                            _ => "",
+                            DiagnosticSeverity::Error => "{InfoDiagnosticError}",
+                            DiagnosticSeverity::Warning => "{InfoDiagnosticWarning}",
+                            DiagnosticSeverity::Information => "{InfoDiagnosticInformation}",
+                            DiagnosticSeverity::Hint => "{InfoDiagnosticHint}",
                         })
                         .unwrap_or_else(|| "");
 

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -50,9 +50,24 @@ pub fn editor_hover(
                             && end.line == pos.line
                             && pos.character <= end.character)
                 })
-                .map(|x| str::trim(&x.message))
-                .filter(|x| !x.is_empty())
-                .map(|x| format!("• {}", x))
+                .filter_map(|x| {
+                    let message = markdown_to_kakoune_markup(&x.message);
+                    let face = x
+                        .severity
+                        .map(|sev| match sev {
+                            DiagnosticSeverity::Error => "{DiagnosticError}",
+                            DiagnosticSeverity::Warning => "{DiagnosticWarning}",
+                            DiagnosticSeverity::Information => "{Information}",
+                            _ => "",
+                        })
+                        .unwrap_or_else(|| "");
+
+                    if !message.is_empty() {
+                        Some(format!("{}• {}", face, message.trim()))
+                    } else {
+                        None
+                    }
+                })
                 .join("\n")
         })
         .unwrap_or_else(String::new);

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -72,7 +72,10 @@ pub fn editor_hover(
                     }
                 })
                 .join("\n"),
-            HoverContents::Markup(contents) => contents.value,
+            HoverContents::Markup(contents) => match contents.kind {
+                MarkupKind::Markdown => markdown_to_kakoune_markup(contents.value),
+                _ => contents.value,
+            },
         },
     };
 

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -63,7 +63,7 @@ pub fn editor_hover(
                         .unwrap_or_else(|| "");
 
                     if !message.is_empty() {
-                        Some(format!("{}• {}", face, message.trim()))
+                        Some(format!("{}• {}{{default}}", face, message.trim()))
                     } else {
                         None
                     }

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -63,7 +63,7 @@ pub fn editor_hover(
                         .unwrap_or_else(|| "");
 
                     if !message.is_empty() {
-                        Some(format!("{}• {}{{default}}", face, message.trim()))
+                        Some(format!("{}• {}{{default}}", face, message))
                     } else {
                         None
                     }

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -85,14 +85,8 @@ pub fn editor_hover(
             HoverContents::Array(contents) => contents
                 .into_iter()
                 .map(parse_marked_string)
-                .filter_map(|markup| {
-                    if !markup.is_empty() {
-                        Some(format!("• {}", markup))
-                    } else {
-                        None
-                    }
-                })
-                .join("\n"),
+                .filter(|markup| !markup.is_empty())
+                .join(&format!("\n{{{}}}---{{{}}}\n", FACE_RULE, FACE_DEFAULT)),
             HoverContents::Markup(contents) => match contents.kind {
                 MarkupKind::Markdown => markdown_to_kakoune_markup(contents.value),
                 MarkupKind::PlainText => contents.value,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -105,7 +105,7 @@ pub fn editor_hover(
                 .join("\n"),
             HoverContents::Markup(contents) => match contents.kind {
                 MarkupKind::Markdown => markdown_to_kakoune_markup(contents.value),
-                _ => contents.value,
+                MarkupKind::PlainText => contents.value,
             },
         },
     };

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -53,12 +53,12 @@ pub fn editor_hover(
                     let face = x
                         .severity
                         .map(|sev| match sev {
-                            DiagnosticSeverity::Error => FACE_DIAGNOSTIC_ERROR,
-                            DiagnosticSeverity::Warning => FACE_DIAGNOSTIC_WARNING,
-                            DiagnosticSeverity::Information => FACE_DIAGNOSTIC_INFO,
-                            DiagnosticSeverity::Hint => FACE_DIAGNOSTIC_HINT,
+                            DiagnosticSeverity::Error => FACE_INFO_DIAGNOSTIC_ERROR,
+                            DiagnosticSeverity::Warning => FACE_INFO_DIAGNOSTIC_WARNING,
+                            DiagnosticSeverity::Information => FACE_INFO_DIAGNOSTIC_INFO,
+                            DiagnosticSeverity::Hint => FACE_INFO_DIAGNOSTIC_HINT,
                         })
-                        .unwrap_or(FACE_DEFAULT);
+                        .unwrap_or(FACE_INFO_DEFAULT);
 
                     if !x.message.is_empty() {
                         // Append FACE_DEFAULT to prevent bleeding over into the next entry
@@ -68,7 +68,7 @@ pub fn editor_hover(
                             // Indent line breaks to the same level as the bullet point
                             // and escape for Kakoune's markup syntax.
                             escape_brace(&x.message.replace("\n", "\n  ")),
-                            FACE_DEFAULT
+                            FACE_INFO_DEFAULT
                         ))
                     } else {
                         None
@@ -86,7 +86,7 @@ pub fn editor_hover(
                 .into_iter()
                 .map(parse_marked_string)
                 .filter(|markup| !markup.is_empty())
-                .join(&format!("\n{{{}}}---{{{}}}\n", FACE_RULE, FACE_DEFAULT)),
+                .join(&format!("\n{{{}}}---{{{}}}\n", FACE_INFO_RULE, FACE_INFO_DEFAULT)),
             HoverContents::Markup(contents) => match contents.kind {
                 MarkupKind::Markdown => markdown_to_kakoune_markup(contents.value),
                 MarkupKind::PlainText => contents.value,

--- a/src/util.rs
+++ b/src/util.rs
@@ -360,8 +360,8 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     }
 
     if let Some(trimmed) = markup.strip_suffix("{default}") {
-        trimmed.to_owned()
+        trimmed.trim().to_owned()
     } else {
-        markup
+        markup.trim().to_owned()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -244,6 +244,7 @@ pub fn short_file_path<'a>(target: &'a str, current_dir: &str) -> &'a str {
         .unwrap_or(target)
 }
 
+/// Parses Markdown into Kakoune's markup syntax using faces for highlighting
 pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     let markdown = markdown.as_ref();
     let parser = Parser::new(markdown);
@@ -254,9 +255,9 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     // State to indicate a block quote
     let mut is_blockquote = false;
     // State to indicate that at least one text line in a block quote
-    // as been emitted
+    // has been emitted
     let mut has_blockquote_text = false;
-    // A rudimentary stack to track nested lists.
+    // A stack to track nested lists.
     // The value tracks ordered vs unordered and the current entry number.
     let mut list_stack: Vec<Option<u64>> = vec![];
 
@@ -265,7 +266,8 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
             Event::Start(tag) => match tag {
                 Tag::Paragraph => {
                     // Block quotes with empty lines are parsed into paragraphes.
-                    // However, even for the first of such paragraphs, `Tag::Blockquote` is emitted first.
+                    // However, even for the first of such paragraphs, `Tag::Blockquote`
+                    // is emitted first.
                     // Since we don't want two `>` at the start, we need to wait for the text first.
                     if is_blockquote && has_blockquote_text {
                         markup.push('>');
@@ -273,7 +275,7 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                     markup.push('\n')
                 }
                 Tag::Heading(level) => {
-                    // Color has `{header}` but keep the Markdown syntax to visualize the header level
+                    // Color as `{header}` but keep the Markdown syntax to visualize the header level
                     markup.push_str(&format!("\n{{header}}{} ", "#".repeat(level as usize)))
                 }
                 Tag::CodeBlock(_) => {
@@ -304,8 +306,10 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                 }
                 Tag::Emphasis => markup.push_str("{default+i}"),
                 Tag::Strong => markup.push_str("{default+b}"),
-                // Kakoune doesn't support clickable links and the URL might be too long to show nicely.
-                // We'll only show the link title for now, which should be enough to search in the relevant resource.
+                // Kakoune doesn't support clickable links and the URL might be too long to show
+                // nicely.
+                // We'll only show the link title for now, which should be enough to search in the
+                // relevant resource.
                 Tag::Link(_, _, _) => markup.push_str("{link}"),
                 Tag::BlockQuote => is_blockquote = true,
                 _ => {}
@@ -344,7 +348,8 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                 markup.push_str(&text.replace("{", "\\{"))
             }
             Event::Html(html) => markup.push_str(&html.replace("{", "\\{")),
-            // We don't know the size of the final render area, so we'll stick to just Markdown syntax
+            // We don't know the size of the final render area, so we'll stick to just Markdown
+            // syntax.
             Event::Rule => markup.push_str("\n{comment}---{default}\n"),
             // Soft breaks should be kept in `<pre>`-style blocks.
             // Anywhere else, let the renderer handle line breaks.

--- a/src/util.rs
+++ b/src/util.rs
@@ -418,9 +418,15 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
         }
     }
 
-    if let Some(trimmed) = markup.strip_suffix("{default}") {
-        trimmed.trim().to_owned()
-    } else {
-        markup.trim().to_owned()
-    }
+    // Trim trailing whitespace and add a `{default}` at the end,
+    // to prevent bleeding markup when concatenated with other text.
+    // In some cases a `{default}` has been added after the trailing whitespace,
+    // so we need to strip that first.
+    let mut markup = markup
+        .strip_suffix("{default}")
+        .unwrap_or(&markup)
+        .trim()
+        .to_owned();
+    markup.push_str("{default}");
+    markup
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -316,7 +316,7 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                     // The parser shouldn't allow this to be empty
                     list.pop()
                         .expect("Event::End(Tag::List) before Event::Start(Tag::List)");
-                    if list.len() == 0 {
+                    if list.is_empty() {
                         markup.push('\n');
                     }
                 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -249,19 +249,19 @@ pub fn short_file_path<'a>(target: &'a str, current_dir: &str) -> &'a str {
         .unwrap_or(target)
 }
 
-pub const FACE_DEFAULT: &str = "InfoDefault";
-pub const FACE_HEADER: &str = "InfoHeader";
-pub const FACE_BLOCK: &str = "InfoBlock";
-pub const FACE_LIST_ITEM: &str = "InfoBullet";
-pub const FACE_LINK: &str = "InfoLink";
-pub const FACE_MONO: &str = "InfoMono";
-pub const FACE_LINK_MONO: &str = "InfoLinkMono";
-pub const FACE_RULE: &str = "InfoRule";
-pub const FACE_QUOTE: &str = "InfoQuote";
-pub const FACE_DIAGNOSTIC_INFO: &str = "InfoDiagnosticInformation";
-pub const FACE_DIAGNOSTIC_HINT: &str = "InfoDiagnosticHint";
-pub const FACE_DIAGNOSTIC_ERROR: &str = "InfoDiagnosticError";
-pub const FACE_DIAGNOSTIC_WARNING: &str = "InfoDiagnosticWarning";
+pub const FACE_INFO_DEFAULT: &str = "InfoDefault";
+pub const FACE_INFO_HEADER: &str = "InfoHeader";
+pub const FACE_INFO_BLOCK: &str = "InfoBlock";
+pub const FACE_INFO_LIST_ITEM: &str = "InfoBullet";
+pub const FACE_INFO_LINK: &str = "InfoLink";
+pub const FACE_INFO_MONO: &str = "InfoMono";
+pub const FACE_INFO_LINK_MONO: &str = "InfoLinkMono";
+pub const FACE_INFO_RULE: &str = "InfoRule";
+pub const FACE_INFO_BLOCK_QUOTE: &str = "InfoBlockQuote";
+pub const FACE_INFO_DIAGNOSTIC_INFO: &str = "InfoDiagnosticInformation";
+pub const FACE_INFO_DIAGNOSTIC_HINT: &str = "InfoDiagnosticHint";
+pub const FACE_INFO_DIAGNOSTIC_ERROR: &str = "InfoDiagnosticError";
+pub const FACE_INFO_DIAGNOSTIC_WARNING: &str = "InfoDiagnosticWarning";
 
 /// Parses Markdown into Kakoune's markup syntax using faces for highlighting
 pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
@@ -288,7 +288,10 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     /// Get the current base face, either the top face on the stack
     /// or a fallback
     fn get_base_face(stack: &Vec<String>) -> &str {
-        stack.last().map(|s| s.as_str()).unwrap_or(FACE_DEFAULT)
+        stack
+            .last()
+            .map(|s| s.as_str())
+            .unwrap_or(FACE_INFO_DEFAULT)
     }
 
     /// Removes the top most face from the stack, then returns the next entry
@@ -312,25 +315,25 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                     markup.push('\n')
                 }
                 Tag::Heading(level) => {
-                    face_stack.push(FACE_HEADER.into());
+                    face_stack.push(FACE_INFO_HEADER.into());
                     // Color as `{header}` but keep the Markdown syntax to visualize the header level
                     markup.push_str(&format!(
                         "\n{{{}}}{} ",
-                        FACE_HEADER,
+                        FACE_INFO_HEADER,
                         "#".repeat(level as usize)
                     ))
                 }
                 Tag::CodeBlock(_) => {
                     is_codeblock = true;
-                    face_stack.push(FACE_BLOCK.into());
-                    markup.push_str(&format!("\n{{{}}}", FACE_BLOCK))
+                    face_stack.push(FACE_INFO_BLOCK.into());
+                    markup.push_str(&format!("\n{{{}}}", FACE_INFO_BLOCK))
                 }
                 Tag::List(num) => list_stack.push(num),
                 Tag::Item => {
                     let base_face = face_stack
                         .last()
                         .map(|s| s.as_str())
-                        .unwrap_or(FACE_DEFAULT);
+                        .unwrap_or(FACE_INFO_DEFAULT);
 
                     let list_level = list_stack.len();
                     // The parser shouldn't allow this to be empty
@@ -340,7 +343,7 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                         markup.push_str(&format!(
                             "\n{}{{{}}}{}. {{{}}}",
                             "  ".repeat(list_level),
-                            FACE_LIST_ITEM,
+                            FACE_INFO_LIST_ITEM,
                             num,
                             base_face
                         ));
@@ -350,7 +353,7 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                         markup.push_str(&format!(
                             "\n{}{{{}}}- {{{}}}",
                             "  ".repeat(list_level),
-                            FACE_LIST_ITEM,
+                            FACE_INFO_LIST_ITEM,
                             base_face
                         ));
                         list_stack.push(item);
@@ -369,12 +372,12 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                 // We'll only show the link title for now, which should be enough to search in the
                 // relevant resource.
                 Tag::Link(_, _, _) => {
-                    face_stack.push(FACE_LINK.into());
-                    markup.push_str(&format!("{{{}}}", FACE_LINK))
+                    face_stack.push(FACE_INFO_LINK.into());
+                    markup.push_str(&format!("{{{}}}", FACE_INFO_LINK))
                 }
                 Tag::BlockQuote => {
-                    face_stack.push(FACE_QUOTE.into());
-                    markup.push_str(&format!("{{{}}}", FACE_QUOTE));
+                    face_stack.push(FACE_INFO_BLOCK_QUOTE.into());
+                    markup.push_str(&format!("{{{}}}", FACE_INFO_BLOCK_QUOTE));
                     is_blockquote = true
                 }
                 _ => {}
@@ -414,10 +417,10 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
             },
             Event::Code(c) => {
                 let base_face = get_base_face(&face_stack);
-                let face = if base_face == FACE_LINK {
-                    FACE_LINK_MONO
+                let face = if base_face == FACE_INFO_LINK {
+                    FACE_INFO_LINK_MONO
                 } else {
-                    FACE_MONO
+                    FACE_INFO_MONO
                 };
 
                 markup.push_str(&format!(
@@ -439,7 +442,7 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
             // syntax.
             Event::Rule => {
                 let base_face = get_base_face(&face_stack);
-                markup.push_str(&format!("\n{{{}}}---{{{}}}\n", FACE_RULE, base_face));
+                markup.push_str(&format!("\n{{{}}}---{{{}}}\n", FACE_INFO_RULE, base_face));
             }
             // Soft breaks should be kept in `<pre>`-style blocks.
             // Anywhere else, let the renderer handle line breaks.
@@ -460,11 +463,11 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     // In some cases a `{default}` has been added after the trailing whitespace,
     // so we need to strip that first.
     let mut markup = markup
-        .strip_suffix(&format!("{{{}}}", FACE_DEFAULT))
+        .strip_suffix(&format!("{{{}}}", FACE_INFO_DEFAULT))
         .unwrap_or(&markup)
         .trim()
         .to_owned();
-    markup.push_str(&format!("{{{}}}", FACE_DEFAULT));
+    markup.push_str(&format!("{{{}}}", FACE_INFO_DEFAULT));
     markup
 }
 
@@ -473,7 +476,10 @@ pub fn parse_marked_string(contents: MarkedString) -> String {
     match contents {
         MarkedString::String(s) => markdown_to_kakoune_markup(s),
         MarkedString::LanguageString(s) => {
-            format!("{{{}}}{}{{{}}}", FACE_BLOCK, s.value, FACE_DEFAULT)
+            format!(
+                "{{{}}}{}{{{}}}",
+                FACE_INFO_BLOCK, s.value, FACE_INFO_DEFAULT
+            )
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -353,11 +353,11 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                 }
                 Tag::Emphasis => {
                     let base_face = get_base_face(&face_stack, FACE_DEFAULT);
-                    markup.push_str(&format!("{{{}+i}}", base_face))
+                    markup.push_str(&format!("{{+i@{}}}", base_face))
                 }
                 Tag::Strong => {
                     let base_face = get_base_face(&face_stack, FACE_DEFAULT);
-                    markup.push_str(&format!("{{{}+b}}", base_face))
+                    markup.push_str(&format!("{{+b@{}}}", base_face))
                 }
                 // Kakoune doesn't support clickable links and the URL might be too long to show
                 // nicely.

--- a/src/util.rs
+++ b/src/util.rs
@@ -132,6 +132,11 @@ pub fn editor_quote(s: &str) -> String {
     format!("'{}'", editor_escape(s))
 }
 
+/// Espace opening braces for Kakoune markup strings
+pub fn escape_brace(s: &str) -> String {
+    s.replace("{", "\\{")
+}
+
 // Cleanup and gracefully exit
 pub fn goodbye(session: &str, code: i32) {
     if code == 0 {
@@ -337,17 +342,15 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
                 Tag::Emphasis | Tag::Strong | Tag::Link(_, _, _) => markup.push_str("{default}"),
                 _ => {}
             },
-            Event::Code(c) => {
-                markup.push_str(&format!("{{mono}}{}{{default}}", c.replace("{", "\\{")))
-            }
+            Event::Code(c) => markup.push_str(&format!("{{mono}}{}{{default}}", escape_brace(&c))),
             Event::Text(text) => {
                 if is_blockquote {
                     has_blockquote_text = true;
                     markup.push_str("> ")
                 }
-                markup.push_str(&text.replace("{", "\\{"))
+                markup.push_str(&escape_brace(&text))
             }
-            Event::Html(html) => markup.push_str(&html.replace("{", "\\{")),
+            Event::Html(html) => markup.push_str(&escape_brace(&html)),
             // We don't know the size of the final render area, so we'll stick to just Markdown
             // syntax.
             Event::Rule => markup.push_str("\n{comment}---{default}\n"),

--- a/src/util.rs
+++ b/src/util.rs
@@ -359,5 +359,9 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
         }
     }
 
-    markup
+    if let Some(trimmed) = markup.strip_suffix("{default}") {
+        trimmed.to_owned()
+    } else {
+        markup
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -262,14 +262,18 @@ fn pop_base_face<'a>(stack: &'a mut Vec<String>, default: &'a str) -> &'a str {
     get_base_face(stack, default)
 }
 
-const FACE_DEFAULT: &str = "InfoDefault";
-const FACE_HEADER: &str = "InfoHeader";
-const FACE_BLOCK: &str = "InfoBlock";
-const FACE_LIST_ITEM: &str = "InfoBullet";
-const FACE_LINK: &str = "InfoLink";
-const FACE_MONO: &str = "InfoMono";
-const FACE_LINK_MONO: &str = "InfoLinkMono";
-const FACE_RULE: &str = "InfoRule";
+pub const FACE_DEFAULT: &str = "InfoDefault";
+pub const FACE_HEADER: &str = "InfoHeader";
+pub const FACE_BLOCK: &str = "InfoBlock";
+pub const FACE_LIST_ITEM: &str = "InfoBullet";
+pub const FACE_LINK: &str = "InfoLink";
+pub const FACE_MONO: &str = "InfoMono";
+pub const FACE_LINK_MONO: &str = "InfoLinkMono";
+pub const FACE_RULE: &str = "InfoRule";
+pub const FACE_DIAGNOSTIC_INFO: &str = "InfoDiagnosticInformation";
+pub const FACE_DIAGNOSTIC_HINT: &str = "InfoDiagnosticHint";
+pub const FACE_DIAGNOSTIC_ERROR: &str = "InfoDiagnosticError";
+pub const FACE_DIAGNOSTIC_WARNING: &str = "InfoDiagnosticWarning";
 
 /// Parses Markdown into Kakoune's markup syntax using faces for highlighting
 pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -462,13 +462,11 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     // to prevent bleeding markup when concatenated with other text.
     // In some cases a `{default}` has been added after the trailing whitespace,
     // so we need to strip that first.
-    let mut markup = markup
+    markup
         .strip_suffix(&format!("{{{}}}", FACE_INFO_DEFAULT))
         .unwrap_or(&markup)
         .trim()
-        .to_owned();
-    markup.push_str(&format!("{{{}}}", FACE_INFO_DEFAULT));
-    markup
+        .to_owned()
 }
 
 /// Parse the contents of a `lsp_types::MarkedString` into Kakoune markup

--- a/src/util.rs
+++ b/src/util.rs
@@ -455,3 +455,13 @@ pub fn markdown_to_kakoune_markup<S: AsRef<str>>(markdown: S) -> String {
     markup.push_str(&format!("{{{}}}", FACE_DEFAULT));
     markup
 }
+
+/// Parse the contents of a `lsp_types::MarkedString` into Kakoune markup
+pub fn parse_marked_string(contents: MarkedString) -> String {
+    match contents {
+        MarkedString::String(s) => markdown_to_kakoune_markup(s),
+        MarkedString::LanguageString(s) => {
+            format!("{{{}}}{}{{{}}}", FACE_BLOCK, s.value, FACE_DEFAULT)
+        }
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/kak-lsp/kak-lsp/pull/337 (which I only noticed half-way into this), this uses [pulldown-cmark](https://crates.io/crates/pulldown-cmark) to parse Markdown into a markup string usable with `:info -markup`.

Links are highlighted, but only their name/title is shown. Syntax and URL are stripped. URLs could be very long and potentially bloat the output. And you can't select them to copy, either. The link name/title should be enough to search for in the relevant resource.

Images are stripped completely. Similar to links, even if the URL was shown, it wouldn't help much.

Code is not highlighted per-language, just the regular `{mono}` and `{block}` faces. Ideally, there would be a simple way to query the editor to run its highlighters, but I don't think there is.
~~Semantic Tokens from the LSP server might be an option too.~~ Token requests only work on files.
Because of this, the "Signature Help" feature has been left untouched, as the values here are just code snippets.

**Open issues:**

- [x] Multi-line code blocks are broken: https://github.com/mawww/kakoune/issues/4313. Do we want to add a workaround?
  Fixed upstream.
- [x] I am reusing existing faces from the Markdown highlighter and existing diagnostics rendering. This has worked fine for me so far.
  But since most colour schemes use a different background for the info box than the buffer, this might not always work.
  Do we want to create a new set of faces for this?
- [ ] Currently, I only have set up `rust-analyzer` to test with.
- [x] The info box used for autocompletion doesn't seem to support markup strings. So I haven't touched that at all.

Fixes #73, #476.