### PR TITLE
Consolidate inlay diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Bug fixes:
 - Fix jumping to locations when Kakoune working directory is different from project root (#517).
 - Diagnostics of level "info" and "hint" are no longer shown as "warning", and are given distinct faces. Also, `find-next-error` will skip over "info" and "hint" diagnostics (#516).
 
+Additions:
+- Multiple inlay diagnostics on a single line are coalesced (#515).
+
 ## 11.0.0 - 2021-09-01
 
 Breaking changes:

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -70,6 +70,9 @@ declare-option -docstring "Character to signal an error in the gutter" str lsp_d
 declare-option -docstring "Character to signal a hint in the gutter" str lsp_diagnostic_line_hint_sign '-'
 declare-option -docstring "Character to signal an info in the gutter" str lsp_diagnostic_line_info_sign 'i'
 declare-option -docstring "Character to signal a warning in the gutter" str lsp_diagnostic_line_warning_sign '!'
+# Visual settings for inlay diagnostics
+declare-option -docstring "Character to represent a single inlay diagnostic of many on a line. May not contain '|'" str lsp_inlay_diagnostic_sign '■'
+declare-option -docstring "Character(s) to separate the actual line contents from the inlay diagnostics. May not contain '|'" str lsp_inlay_diagnostic_gap '     '
 # Another good default:
 # set-option global lsp_diagnostic_line_error_sign '▓'
 # set-option global lsp_diagnostic_line_warning_sign '▒'

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -5,7 +5,7 @@ use crate::util::*;
 use itertools::Itertools;
 use jsonrpc_core::Params;
 use lsp_types::*;
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
     let params: PublishDiagnosticsParams = params.parse().expect("Failed to parse params");
@@ -69,37 +69,69 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
             )
         })
         .join(" ");
-    let mut lines_with_errors = HashSet::new();
-    let diagnostic_ranges = diagnostics
+
+    // Assemble a list of diagnostics by line number
+    let mut lines_with_diagnostics = HashMap::new();
+    for diagnostic in diagnostics {
+        let face = match diagnostic.severity {
+            Some(DiagnosticSeverity::Error) => "InlayDiagnosticError",
+            Some(DiagnosticSeverity::Hint) => "InlayDiagnosticHint",
+            Some(DiagnosticSeverity::Information) => "InlayDiagnosticInfo",
+            Some(DiagnosticSeverity::Warning) | None => "InlayDiagnosticWarning",
+        };
+        let line_diagnostics = lines_with_diagnostics
+            .entry(diagnostic.range.end.line)
+            .or_insert(LineDiagnostics {
+                range_end: diagnostic.range.end,
+                symbols: String::new(),
+                text: String::new(),
+                text_face: "",
+                text_severity: None,
+            });
+
+        let severity = diagnostic.severity.unwrap_or(DiagnosticSeverity::Warning);
+        if line_diagnostics
+            .text_severity
+            // Smaller == higher severity
+            .map_or(true, |text_severity| severity < text_severity)
+        {
+            line_diagnostics.text = diagnostic
+                .message
+                .split('\n')
+                .next()
+                .unwrap_or_default()
+                .replace("|", "\\|");
+            line_diagnostics.text_face = face;
+            line_diagnostics.text_severity = diagnostic.severity;
+        }
+
+        line_diagnostics
+            .symbols
+            .push_str(&format!("{{{}}}%opt[lsp_inlay_diagnostic_sign]", face))
+    }
+
+    // Assemble ranges based on the lines
+    let diagnostic_ranges = lines_with_diagnostics
         .iter()
-        .map(|x| {
-            let face = match x.severity {
-                Some(DiagnosticSeverity::Error) => "InlayDiagnosticError",
-                Some(DiagnosticSeverity::Hint) => "InlayDiagnosticHint",
-                Some(DiagnosticSeverity::Information) => "InlayDiagnosticInfo",
-                Some(DiagnosticSeverity::Warning) | None => "InlayDiagnosticWarning",
-            };
-            // Pretend the language server sent us the diagnostic past the end of line
-            let line = x.range.end.line;
-            let line_text = get_line(line as usize, &document.text);
-            let mut pos =
-                lsp_position_to_kakoune(&x.range.end, &document.text, ctx.offset_encoding);
+        .map(|(line_number, line_diagnostics)| {
+            let line_text = get_line(*line_number as usize, &document.text);
+            let mut pos = lsp_position_to_kakoune(
+                &line_diagnostics.range_end,
+                &document.text,
+                ctx.offset_encoding,
+            );
             pos.column = line_text.len_bytes() as u32;
-            // separate all but the first diagnostic on the same line
-            let sep = if lines_with_errors.insert(line) {
-                ""
-            } else {
-                ", "
-            };
-            editor_quote(&format!(
-                "{}+0|{{{}}}{{\\}}{} {}",
+
+            format!(
+                "\"{}+0|%opt[lsp_inlay_diagnostic_gap]{} {{{}}}{{\\}}{}\"",
                 pos,
-                face,
-                sep,
-                x.message.replace("|", "\\|")
-            ))
+                line_diagnostics.symbols,
+                line_diagnostics.text_face,
+                editor_escape(&line_diagnostics.text)
+            )
         })
         .join(" ");
+
     // Always show a space on line one if no other highlighter is there,
     // to make sure the column always has the right width
     // Also wrap line_flags in another eval and quotes, to make sure the %opt[] tags are expanded

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use jsonrpc_core::{Call, Output, Params};
-use lsp_types::{Range, SemanticTokenModifier};
+use lsp_types::{DiagnosticSeverity, Position, Range, SemanticTokenModifier};
 use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::borrow::Cow;
@@ -234,4 +234,13 @@ pub enum OffsetEncoding {
     /// UTF-16 code units
     #[serde(rename = "utf-16")]
     Utf16,
+}
+
+// An intermediate representation of the diagnostics on a line, for use with inlay diagnostics
+pub struct LineDiagnostics {
+    pub range_end: Position,
+    pub symbols: String,
+    pub text: String,
+    pub text_face: &'static str,
+    pub text_severity: Option<DiagnosticSeverity>,
 }


### PR DESCRIPTION
Currently, inlay diagnostics are shown all in a row, one after the other. This makes them very difficult to digest when there are a lot of them.

Neovim's new built-in LSP client does inlay diagnostics in a way that I immediately loved, so I have implemented it here. The following changes were made:

- Added a five-space gap between the actual line and the diagnostics (this can be changed via the `lsp_inlay_diagnostic_gap` option)
- Added a symbol (`lsp_inlay_diagnostic_sign`) that is shown for each diagnostic on the line, and is colored accordingly
- Only the first line of the first diagnostic is printed

**Before:**

![image](https://user-images.githubusercontent.com/3515394/132293865-65768282-ee4e-489e-aceb-c51855722106.png)

**After:**

![image](https://user-images.githubusercontent.com/3515394/132293887-603f086d-25d3-4bf3-b840-b3947248c724.png)

I'm still fairly new to Rust, so I fully expect my code to be ripped apart and destroyed. It works just fine, but it turns what was a single pass into two passes, and makes a bunch of heap allocations that weren't there before. There's bound to be ways to improve it.