### PR TITLE
Add hint and info diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Unreleased
 
+Breaking changes:
+- The face `LineFlagErrors` has been renamed to `LineFlagError`, for consistency with other faces (#516).
+
 Bug fixes:
 - Fix example server configuration for `lua-language-server`.
 - Fix completion of Rust lifetimes (#510).
 - `lsp-highlight-references` clears highlights on failure, improving the behavior when `%opt{lsp_auto_highlight_references}` is true (#457).
 - Fix jumping to locations when Kakoune working directory is different from project root (#517).
+- Diagnostics of level "info" and "hint" are no longer shown as "warning", and are given distinct faces. Also, `find-next-error` will skip over "info" and "hint" diagnostics (#516).
 
 ## 11.0.0 - 2021-09-01
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -142,8 +142,8 @@ Either way you get:
 ** `\*symbols*` buffer has filetype `lsp-goto` so you can press `<ret>` on a line or use the `lsp-jump` command
 * `lsp-diagnostics` command to list project-wide diagnostics (current buffer determines project and language to collect diagnostics for)
 ** `\*diagnostics*` buffer has filetype `lsp-goto` so you can press `<ret>` on a line or use the `lsp-jump` command
-* inline diagnostics highlighting using the `DiagnosticError` and `DiagnosticWarning` faces; can be disabled with `lsp-inline-diagnostics-disable` command
-* flags in the left margin on lines with errors or warnings; can be disabled with `lsp-diagnostic-lines-disable` command
+* inline diagnostics highlighting using the `DiagnosticError`, `DiagnosticHint`, `DiagnosticInfo` and `DiagnosticWarning` faces; can be disabled with `lsp-inline-diagnostics-disable` command
+* flags in the left margin on lines with errors or other diagnostics; can be disabled with `lsp-diagnostic-lines-disable` command
 * `lsp-formatting` command to format current buffer, according to the `tabstop` and `lsp_insert_spaces` options
 * `lsp-formatting-sync` command to format current buffer synchronously, suitable for use with `BufWritePre` hook:
 
@@ -155,7 +155,7 @@ hook global WinSetOption filetype=rust %{
 
 * `lsp-rename <new_name>` and `lsp-rename-prompt` commands to rename the symbol under the main cursor.
 * `lsp-code-actions` command to open a menu with code actions available at the main cursor position
-* `lsp_diagnostic_error_count`  and `lsp_diagnostic_warning_count` options which contain the number of errors and warnings diagnosed for the current buffer. For example, you can put it into your modeline to see at a glance if there are errors in the current file
+* `lsp_diagnostic_error_count`, `lsp_diagnostic_hint_count`, `lsp_diagnostic_info_count` and `lsp_diagnostic_warning_count` options which contain the number of diagnostics of the respective level for the current buffer. For example, you can put it into your modeline to see at a glance if there are errors in the current file
 * starting new kak-lsp session when Kakoune session begins and stopping it when Kakoune session ends
 
 NOTE: By default, kak-lsp exits when it doesn't receive any request from Kakoune for 30 minutes,
@@ -244,8 +244,7 @@ arbitrary sections that are requested by the server in `workspace/configuration`
 kak-lsp's Kakoune integration declares the following options:
 
 * `lsp_completion_trigger` (str): This option is set to a Kakoune command, which is executed every time the user pauses in insert mode. If the command succeeds, kak-lsp will send a completion request to the language server.
-* `lsp_diagnostic_line_error_sign` (str): When using `lsp-diagnostic-lines-enable` and the language server detects an error, kak-lsp will add a flag to the left-most column of the window, using this string and the `LineFlagErrors` face.
-* `lsp_diagnostic_line_warning_sign` (str): When using `lsp-diagnostic-lines-enable` and the language server detects a warning, kak-lsp will add a flag to the left-most column of the window, using this string and the `LineFlagErrors` face.
+* `lsp_diagnostic_line_error_sign`, `lsp_diagnostic_line_hint_sign`, `lsp_diagnostic_line_info_sign`, and `lsp_diagnostic_line_warning_sign` (str): When using `lsp-diagnostic-lines-enable` and the language server detects an error or another diagnostic, kak-lsp will add a flag to the left-most column of the window, using this string and one of the corresponding faces `LineFlagError`, `LineFlagHint`, `LineFlagInfo` or `LineFlagWarning`.
 * `lsp_hover_anchor` (bool): When using `lsp-hover` or `lsp-auto-hover-enable`, if this option is `true` then the hover information will be displayed next to the active selection. Otherwise, the information will be displayed in a box in the lower-right corner.
 * `lsp_hover_max_lines` (int): If greater than 0 then limit rendered hover information to the given number of lines.
 * `lsp_hover_insert_mode_trigger` (str): This option is set to a Kakoune command. When using `lsp-auto-hover-insert-mode-enable`, this command is executed every time the user pauses in insert mode. If the command succeeds, kak-lsp will send a hover-information request for the text selected by the command.

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1162,13 +1162,13 @@ define-command lsp-find-error -params 0..2 -docstring "lsp-find-error [--previou
 Jump to the next or previous diagnostic error" %{
     evaluate-commands %sh{
         previous=false
-        errorCompare="DiagnosticError"
         if [ "$1" = "--previous" ]; then
             previous=true
             shift
         fi
+        includeWarnings=false
         if [ "$1" = "--include-warnings" ]; then
-            errorCompare="Diagnostic"
+            includeWarnings=true
         fi
         #expand quoting, stores option in $@
         eval set -- "${kak_quoted_opt_lsp_errors}"
@@ -1178,7 +1178,9 @@ Jump to the next or previous diagnostic error" %{
         prev=""
         selection=""
         for e in "$@"; do
-            if [ -z "${e##*${errorCompare}*}" ]; then # e contains errorCompare
+            if [ -z "${e##*DiagnosticError*}" ] || {
+                $includeWarnings && [ -z "${e##*DiagnosticWarning*}" ]
+            } then # e is an error or warning
                 e=${e%,*}
                 line=${e%.*}
                 column=${e#*.}

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -8,12 +8,19 @@ declare-option -docstring "Command with which lsp is run" str lsp_cmd "kak-lsp -
 
 # Faces used by inline diagnostics.
 set-face global DiagnosticError red
+set-face global DiagnosticHint default
+set-face global DiagnosticInfo default
 set-face global DiagnosticWarning yellow
 # Faces used by inlay diagnostics.
 set-face global InlayDiagnosticError DiagnosticError
+set-face global InlayDiagnosticHint DiagnosticHint
+set-face global InlayDiagnosticInfo DiagnosticInfo
 set-face global InlayDiagnosticWarning DiagnosticWarning
-# Line flags for errors and warnings both use this face.
-set-face global LineFlagErrors red
+# Faces used by line flags
+set-face global LineFlagError red
+set-face global LineFlagHint default
+set-face global LineFlagInfo default
+set-face global LineFlagWarning yellow
 # Face for highlighting references.
 set-face global Reference MatchingChar
 set-face global ReferenceBind +u@Reference
@@ -60,6 +67,8 @@ declare-option -docstring "DEPRECATED, use %opt{lsp_config}. Configuration to se
 declare-option -docstring "DEPRECATED, use %opt{lsp_config}. Configuration to send in initializationOptions of Initialize messages." str-to-str-map lsp_server_initialization_options
 # Line flags for inline diagnostics.
 declare-option -docstring "Character to signal an error in the gutter" str lsp_diagnostic_line_error_sign '*'
+declare-option -docstring "Character to signal a hint in the gutter" str lsp_diagnostic_line_hint_sign '-'
+declare-option -docstring "Character to signal an info in the gutter" str lsp_diagnostic_line_info_sign 'i'
 declare-option -docstring "Character to signal a warning in the gutter" str lsp_diagnostic_line_warning_sign '!'
 # Another good default:
 # set-option global lsp_diagnostic_line_error_sign '▓'
@@ -67,7 +76,7 @@ declare-option -docstring "Character to signal a warning in the gutter" str lsp_
 # This is used to render lsp-hover response.
 # By default it shows both hover info and diagnostics.
 declare-option -docstring "Format hover info" str lsp_show_hover_format 'printf ''%s\n\n%s'' "${lsp_info}" "${lsp_diagnostics}"'
-# If you want to see only hover info, try 
+# If you want to see only hover info, try
 # set-option global lsp_show_hover_format 'printf %s "${lsp_info}"'
 declare-option -docstring %{Defines location patterns for lsp-next-location and lsp-previous-location.
 Default locations look like "file:line[:column][:message]"
@@ -83,6 +92,8 @@ Capture groups must be:
 
 # Count of diagnostics published for the current buffer.
 declare-option -docstring "Number of errors" int lsp_diagnostic_error_count 0
+declare-option -docstring "Number of hints" int lsp_diagnostic_hint_count 0
+declare-option -docstring "Number of infos" int lsp_diagnostic_info_count 0
 declare-option -docstring "Number of warnings" int lsp_diagnostic_warning_count 0
 
 # Internal variables.
@@ -425,7 +436,7 @@ define-command -hidden lsp-workspace-symbol-buffer -params 4 -docstring %{
     Open buffer with a list of project-wide symbols matching the query
     on behalf of the buffile at timestamp
 } %{
-    lsp-did-change-and-then "lsp-workspace-symbol-buffer-request '%arg{1}' '%arg{2}' '%arg{3}' '%arg{4}'" 
+    lsp-did-change-and-then "lsp-workspace-symbol-buffer-request '%arg{1}' '%arg{2}' '%arg{3}' '%arg{4}'"
 }
 
 define-command -hidden lsp-workspace-symbol-buffer-request -params 4 -docstring %{
@@ -1245,7 +1256,7 @@ define-command lsp-inline-diagnostics-disable -params 1 -docstring "lsp-inline-d
 }
 
 define-command lsp-diagnostic-lines-enable -params 1 -docstring "lsp-diagnostic-lines-enable <scope>: Show flags on lines with diagnostics in <scope>" %{
-    add-highlighter "%arg{1}/lsp_error_lines" flag-lines LineFlagErrors lsp_error_lines
+    add-highlighter "%arg{1}/lsp_error_lines" flag-lines default lsp_error_lines
 }
 
 define-command lsp-diagnostic-lines-disable -params 1 -docstring "lsp-diagnostic-lines-disable <scope>: Hide flags on lines with diagnostics in <scope>"  %{
@@ -1319,7 +1330,7 @@ declare-user-mode lsp
 map global lsp a '<esc>: lsp-code-actions<ret>'           -docstring 'show code actions for current position'
 map global lsp c '<esc>: lsp-capabilities<ret>'           -docstring 'show language server capabilities'
 map global lsp d '<esc>: lsp-definition<ret>'             -docstring 'go to definition'
-map global lsp e '<esc>: lsp-diagnostics<ret>'            -docstring 'list project errors and warnings'
+map global lsp e '<esc>: lsp-diagnostics<ret>'            -docstring 'list project errors, info, hints and warnings'
 map global lsp f '<esc>: lsp-formatting<ret>'             -docstring 'format buffer'
 map global lsp h '<esc>: lsp-hover<ret>'                  -docstring 'show info for current position'
 map global lsp i '<esc>: lsp-implementation<ret>'         -docstring 'go to implementation'

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -32,7 +32,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
                     Some(DiagnosticSeverity::Error) => "DiagnosticError",
                     Some(DiagnosticSeverity::Hint) => "DiagnosticHint",
                     Some(DiagnosticSeverity::Information) => "DiagnosticInfo",
-                    _ => "DiagnosticWarning",
+                    Some(DiagnosticSeverity::Warning) | None => "DiagnosticWarning",
                 }
             )
         })
@@ -61,7 +61,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
                         info_count += 1;
                         "{LineFlagInfo}%opt[lsp_diagnostic_line_info_sign]"
                     }
-                    _ => {
+                    Some(DiagnosticSeverity::Warning) | None => {
                         warning_count += 1;
                         "{LineFlagWarning}%opt[lsp_diagnostic_line_warning_sign]"
                     }
@@ -77,7 +77,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
                 Some(DiagnosticSeverity::Error) => "InlayDiagnosticError",
                 Some(DiagnosticSeverity::Hint) => "InlayDiagnosticHint",
                 Some(DiagnosticSeverity::Information) => "InlayDiagnosticInfo",
-                _ => "InlayDiagnosticWarning",
+                Some(DiagnosticSeverity::Warning) | None => "InlayDiagnosticWarning",
             };
             // Pretend the language server sent us the diagnostic past the end of line
             let line = x.range.end.line;
@@ -156,7 +156,7 @@ pub fn editor_diagnostics(meta: EditorMeta, ctx: &mut Context) {
                             Some(DiagnosticSeverity::Error) => "error",
                             Some(DiagnosticSeverity::Hint) => "hint",
                             Some(DiagnosticSeverity::Information) => "info",
-                            _ => "warning",
+                            Some(DiagnosticSeverity::Warning) | None => "warning",
                         },
                         x.message
                     )

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -30,14 +30,18 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
                 lsp_range_to_kakoune(&x.range, &document.text, ctx.offset_encoding),
                 match x.severity {
                     Some(DiagnosticSeverity::Error) => "DiagnosticError",
+                    Some(DiagnosticSeverity::Hint) => "DiagnosticHint",
+                    Some(DiagnosticSeverity::Information) => "DiagnosticInfo",
                     _ => "DiagnosticWarning",
                 }
             )
         })
         .join(" ");
 
-    let mut error_count = 0;
-    let mut warning_count = 0;
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+    let mut info_count: u32 = 0;
+    let mut hint_count: u32 = 0;
     let line_flags = diagnostics
         .iter()
         .map(|x| {
@@ -47,11 +51,19 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
                 match x.severity {
                     Some(DiagnosticSeverity::Error) => {
                         error_count += 1;
-                        "%opt[lsp_diagnostic_line_error_sign]"
+                        "{LineFlagError}%opt[lsp_diagnostic_line_error_sign]"
+                    }
+                    Some(DiagnosticSeverity::Hint) => {
+                        hint_count += 1;
+                        "{LineFlagHint}%opt[lsp_diagnostic_line_hint_sign]"
+                    }
+                    Some(DiagnosticSeverity::Information) => {
+                        info_count += 1;
+                        "{LineFlagInfo}%opt[lsp_diagnostic_line_info_sign]"
                     }
                     _ => {
                         warning_count += 1;
-                        "%opt[lsp_diagnostic_line_warning_sign]"
+                        "{LineFlagWarning}%opt[lsp_diagnostic_line_warning_sign]"
                     }
                 }
             )
@@ -63,6 +75,8 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         .map(|x| {
             let face = match x.severity {
                 Some(DiagnosticSeverity::Error) => "InlayDiagnosticError",
+                Some(DiagnosticSeverity::Hint) => "InlayDiagnosticHint",
+                Some(DiagnosticSeverity::Information) => "InlayDiagnosticInfo",
                 _ => "InlayDiagnosticWarning",
             };
             // Pretend the language server sent us the diagnostic past the end of line
@@ -91,11 +105,15 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
     // Also wrap line_flags in another eval and quotes, to make sure the %opt[] tags are expanded
     let command = format!(
         "set buffer lsp_diagnostic_error_count {}; \
+         set buffer lsp_diagnostic_hint_count {}; \
+         set buffer lsp_diagnostic_info_count {}; \
          set buffer lsp_diagnostic_warning_count {}; \
          set buffer lsp_errors {} {}; \
          eval \"set buffer lsp_error_lines {} {} '0| '\"; \
          set buffer lsp_diagnostics {} {}",
         error_count,
+        hint_count,
+        info_count,
         warning_count,
         version,
         ranges,
@@ -136,6 +154,8 @@ pub fn editor_diagnostics(meta: EditorMeta, ctx: &mut Context) {
                         p.column,
                         match x.severity {
                             Some(DiagnosticSeverity::Error) => "error",
+                            Some(DiagnosticSeverity::Hint) => "hint",
+                            Some(DiagnosticSeverity::Information) => "info",
                             _ => "warning",
                         },
                         x.message


### PR DESCRIPTION
It seemed odd to me that `kak-lsp` showed hints and infos as warnings instead of what they actually are, so I added hints and infos properly. Infos are colored blue by default, and hints are cyan (I wanted to make them grey, but there isn't a standard grey color).

I also took the opportunity to split the `LineFlagErrors` option into `LineFlag(Error|Warning|Info|Hint)`. The `flag-lines` highlighter now uses the `default` face, and `kak-lsp` adds the appropriate markup strings to color them.

The result is as thus:

![image](https://user-images.githubusercontent.com/3515394/132440631-d9bec68e-d642-4e23-89f3-7b4bf198b3df.png)

(pictured with the improved inlay diagnostics from #515, and my [one-darker](https://github.com/raiguard/one.kak) color scheme)

The new diagnostic types work in the diagnostics buffer as well:

![image](https://user-images.githubusercontent.com/3515394/132440874-b1cb12e5-fab5-4d36-bc12-6da691a5dc88.png)
