### PR TITLE
Use LineNumbers face for diagnostic flag-lines

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1280,7 +1280,7 @@ define-command lsp-inline-diagnostics-disable -params 1 -docstring "lsp-inline-d
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command lsp-diagnostic-lines-enable -params 1 -docstring "lsp-diagnostic-lines-enable <scope>: Show flags on lines with diagnostics in <scope>" %{
-    add-highlighter "%arg{1}/lsp_error_lines" flag-lines default lsp_error_lines
+    add-highlighter "%arg{1}/lsp_error_lines" flag-lines LineNumbers lsp_error_lines
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command lsp-diagnostic-lines-disable -params 1 -docstring "lsp-diagnostic-lines-disable <scope>: Hide flags on lines with diagnostics in <scope>"  %{


### PR DESCRIPTION
I reckon diagnostic flag-line face should default to `LineNumbers` face to match any colorscheme.

Fixes #524