### PR TITLE
Fix check if text edit replacement will merge selections

### DIFF
--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -316,30 +316,37 @@ fn lsp_text_edit_to_kakoune(
 mod tests {
     use super::*;
 
-    #[test]
-    pub fn text_edits() {
-        let edit = |start, end, new_text: &str| {
-            OneOf::Left(TextEdit {
-                range: Range {
-                    start: Position {
-                        line: 0,
-                        character: start,
-                    },
-                    end: Position {
-                        line: 0,
-                        character: end,
-                    },
+    fn edit(
+        start_line: u32,
+        start_character: u32,
+        end_line: u32,
+        end_character: u32,
+        new_text: &str,
+    ) -> OneOf<TextEdit, AnnotatedTextEdit> {
+        OneOf::Left(TextEdit {
+            range: Range {
+                start: Position {
+                    line: start_line,
+                    character: start_character,
                 },
-                new_text: new_text.to_string(),
-            })
-        };
+                end: Position {
+                    line: end_line,
+                    character: end_character,
+                },
+            },
+            new_text: new_text.to_string(),
+        })
+    }
+
+    #[test]
+    pub fn apply_text_edits_to_buffer_issue_521() {
         let text_edits = vec![
-            edit(4, 7, "std"),
-            edit(7, 9, ""),
-            edit(9, 12, ""),
-            edit(14, 21, "ffi"),
-            edit(21, 21, "::"),
-            edit(21, 21, "{CStr, CString}"),
+            edit(0, 4, 0, 7, "std"),
+            edit(0, 7, 0, 9, ""),
+            edit(0, 9, 0, 12, ""),
+            edit(0, 14, 0, 21, "ffi"),
+            edit(0, 21, 0, 21, "::"),
+            edit(0, 21, 0, 21, "{CStr, CString}"),
         ];
         let buffer = Rope::from_str("use std::ffi::CString;");
         let result =


### PR DESCRIPTION
Extend "remove_adjacent" to include non-empty replacements.  The attached
test case was extracted from a rust-analyzer example. It's not minimized
but the fix is simply that "lsp-replace-selection 'println'" is recognized
to merge with its adjacent (right) neighbor.

Also change the logic for "remove_adjacent" from
(empty && adj1 || adj2) to (empty && (ajd1 || ajd2).
This is arguably more correct.

Because we now recognize more merged selections, we must take care of a
special Kakoune behavior: "|" commands that change nothing preserve selections.
This messes with our logic that would assume they would merge (and go away).
Luckily, we can just drop them since they are redundant.  This causes harmless
changes to the existing test.

Part of #527
Unfortunately, there is another special quirk in Kakoune that prevents #527
from working without needing formatting; see the attached failing test case.
