### PR TITLE
Remove window/progress support and add $/progress support

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -702,6 +702,20 @@ method   = "exit"
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+define-command lsp-cancel-progress -params 1 -docstring "Cancel a cancelable progress item." %{
+    remove-hooks global lsp
+    nop %sh{ (printf '
+session  = "%s"
+client   = "%s"
+buffile  = "%s"
+filetype = "%s"
+version  = %d
+method   = "window/workDoneProgress/cancel"
+[params]
+token    = "%s"
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "$1" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
 define-command lsp-apply-workspace-edit -params 1 -hidden %{
     lsp-did-change-and-then %sh{
         printf "lsp-apply-workspace-edit-request '%s'" "$(printf %s "$1" | sed "s/'/''/g")"
@@ -1301,8 +1315,8 @@ define-command -hidden lsp-replace-selection -params 1 -docstring %{
     }
 }
 
-define-command -hidden lsp-handle-progress -params 4 -docstring %{
-  lsp-handle-progress <title> <message> <percentage> <done>
+define-command -hidden lsp-handle-progress -params 6 -docstring %{
+  lsp-handle-progress <token> <title> <cancelable> <message> <percentage> <done>
   Handle progress messages sent from the language server. Override to handle this.
 } %{ nop }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,6 +41,7 @@ pub struct Context {
     pub session: SessionId,
     pub documents: HashMap<String, Document>,
     pub offset_encoding: OffsetEncoding,
+    pub work_done_progress: HashMap<NumberOrString, Option<WorkDoneProgressBegin>>,
 }
 
 impl Context {
@@ -70,6 +71,7 @@ impl Context {
             session,
             documents: HashMap::default(),
             offset_encoding,
+            work_done_progress: HashMap::default(),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use lsp_types::*;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::fs;
+use std::{fs, time};
 
 // Copy of Kakoune's timestamped buffer content.
 pub struct Document {
@@ -42,6 +42,7 @@ pub struct Context {
     pub documents: HashMap<String, Document>,
     pub offset_encoding: OffsetEncoding,
     pub work_done_progress: HashMap<NumberOrString, Option<WorkDoneProgressBegin>>,
+    pub work_done_progress_report_timestamp: time::Instant,
 }
 
 impl Context {
@@ -72,6 +73,7 @@ impl Context {
             documents: HashMap::default(),
             offset_encoding,
             work_done_progress: HashMap::default(),
+            work_done_progress_report_timestamp: time::Instant::now(),
         }
     }
 

--- a/src/general.rs
+++ b/src/general.rs
@@ -274,7 +274,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 moniker: None,
             }),
             window: Some(WindowClientCapabilities {
-                work_done_progress: Some(false),
+                work_done_progress: Some(true),
                 show_message: None,
                 show_document: None,
             }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod language_features;
 mod language_server_transport;
 mod markup;
 mod position;
+mod progress;
 mod project_root;
 mod session;
 mod settings;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,157 @@
+use crate::context::Context;
+use crate::types::{EditorMeta, EditorParams};
+use crate::util::editor_quote;
+use jsonrpc_core::Params;
+use lsp_types::{
+    notification::WorkDoneProgressCancel, NumberOrString, ProgressParams, ProgressParamsValue,
+    WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressCancelParams,
+    WorkDoneProgressCreateParams, WorkDoneProgressEnd,
+};
+use serde::Deserialize;
+use std::collections::hash_map;
+
+pub fn work_done_progress_cancel(_meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params = WorkDoneProgressCancelParams::deserialize(params).expect("Failed to parse params");
+    ctx.notify::<WorkDoneProgressCancel>(params);
+}
+
+pub fn work_done_progress_create(
+    params: Params,
+    ctx: &mut Context,
+) -> Result<jsonrpc_core::Value, jsonrpc_core::Error> {
+    let WorkDoneProgressCreateParams { token } = params
+        .parse()
+        .map_err(|_| jsonrpc_core::Error::new(jsonrpc_core::ErrorCode::InvalidParams))?;
+    match ctx.work_done_progress.entry(token) {
+        hash_map::Entry::Occupied(e) => {
+            warn!("Received duplicate ProgressToken '{:?}'", e.key());
+        }
+        hash_map::Entry::Vacant(e) => {
+            e.insert(None);
+        }
+    };
+    Ok(jsonrpc_core::Value::Null)
+}
+
+pub fn dollar_progress(meta: EditorMeta, params: Params, ctx: &mut Context) {
+    let params: ProgressParams = match params.parse() {
+        Ok(params) => params,
+        Err(err) => {
+            // Workaround: clangd up to version 12 sends us invalid messages.  Avoid panicking so
+            // other features keep working. This is fixed by LLVM commit f088af37e6b5 ([clangd]
+            // Fix data type of WorkDoneProgressReport::percentage, 2021-05-10).
+            warn!("Failed to parse WorkDoneProgressParams params: {}", err);
+            return;
+        }
+    };
+
+    fn handle_progress_command(
+        token: &lsp_types::ProgressToken,
+        title: &str,
+        cancelable: bool,
+        message: &Option<String>,
+        percentage: &Option<u32>,
+        done: bool,
+    ) -> String {
+        let token = match token {
+            NumberOrString::Number(token) => token.to_string(),
+            NumberOrString::String(token) => editor_quote(token),
+        };
+        format!(
+            "lsp-handle-progress {} {} {} {} {} {}",
+            token,
+            editor_quote(title),
+            cancelable,
+            editor_quote(message.as_deref().unwrap_or_default()),
+            editor_quote(&percentage.map(|x| x.to_string()).unwrap_or_default()),
+            done,
+        )
+    }
+
+    let token = &params.token;
+    match params.value {
+        ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)) => {
+            match ctx.work_done_progress.get_mut(&params.token) {
+                Some(Some(_)) => {
+                    warn!(
+                        "Received begin event for already started ProgressToken '{:?}'",
+                        token
+                    )
+                }
+                Some(progress @ None) => {
+                    let command = handle_progress_command(
+                        token,
+                        &begin.title,
+                        begin.cancellable.unwrap_or(false),
+                        &begin.message,
+                        &begin.percentage,
+                        false,
+                    );
+                    *progress = Some(begin);
+                    ctx.exec(meta, command);
+                }
+                None => {
+                    warn!(
+                        "Received begin event for non-existent ProgressToken '{:?}'",
+                        token
+                    );
+                }
+            }
+        }
+        ProgressParamsValue::WorkDone(WorkDoneProgress::Report(report)) => {
+            match ctx.work_done_progress.get_mut(&params.token) {
+                Some(Some(progress)) => {
+                    let command = handle_progress_command(
+                        token,
+                        &progress.title,
+                        report.cancellable.unwrap_or(false),
+                        &report.message,
+                        &report.percentage,
+                        false,
+                    );
+                    progress.cancellable = report.cancellable;
+                    progress.message = report.message;
+                    progress.percentage = report.percentage;
+                    ctx.exec(meta, command);
+                }
+                Some(None) => {
+                    let token = &params.token;
+                    warn!(
+                        "Received report event for unstarted ProgressToken '{:?}'",
+                        token
+                    );
+                }
+                None => {
+                    let token = &params.token;
+                    warn!(
+                        "Received report event for non-existent ProgressToken '{:?}'",
+                        token
+                    );
+                }
+            }
+        }
+        ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd { message })) => {
+            match ctx.work_done_progress.remove(&params.token) {
+                Some(Some(WorkDoneProgressBegin { title, .. })) => {
+                    let command =
+                        handle_progress_command(token, &title, false, &message, &Some(100), true);
+                    ctx.exec(meta, command);
+                }
+                Some(None) => {
+                    let token = &params.token;
+                    warn!(
+                        "Received end event for unstarted ProgressToken '{:?}'",
+                        token
+                    );
+                }
+                None => {
+                    let token = &params.token;
+                    warn!(
+                        "Received end event for non-existent ProgressToken '{:?}'",
+                        token
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -191,14 +191,6 @@ pub struct TextDocumentRenameParams {
     pub new_name: String,
 }
 
-#[derive(Deserialize, Debug)]
-pub struct WindowProgress {
-    pub title: String,
-    pub message: Option<String>,
-    pub percentage: Option<String>,
-    pub done: Option<bool>,
-}
-
 // Language Server
 
 // XXX serde(untagged) ?


### PR DESCRIPTION
The previous support was added for rust-analyzer and rust-analyzer started using $/progress, so I don't think anyone's using the old support anymore.

`lsp-cancel-progress` isn't very useful unless someone writes a bit of an involved config for it now, but there could be a future `lsp-cancel` that shows a menu of actions to cancel. I haven't implemented that because I haven't encountered a cancellable progress item yet.


This should be the new wiki page for https://github.com/kak-lsp/kak-lsp/wiki/Handling-progress-notifications if this is merged:

~~~
To handle progress notifications, override the `lsp-handle-progress` command. For example:

```
declare-option -hidden str modeline_progress ""
define-command -hidden -params 6 -override lsp-handle-progress %{
  set global modeline_progress %sh{
    if [ "$6" = "no" ]; then
      echo $2${5:+" ($5%)"}${4:+": $4"}
    fi
  }
}
```

And then put %opt{modeline_progress} in your modelinefmt to see what language server is doing.
~~~