### PR TITLE
Semantic tokens updates

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1094,6 +1094,12 @@ method    = "textDocument/semanticTokens/full"
 ' "${kak_session}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
+define-command -hidden lsp-semantic-tokens-refresh %{
+    evaluate-commands %sh{
+        printf 'evaluate-commands -client %s lsp-semantic-tokens-request\n' $kak_quoted_client_list
+    }
+}
+
 ### Response handling ###
 
 # Feel free to override these commands in your config if you need to customise response handling.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -341,6 +341,7 @@ fn dispatch_server_request(request: MethodCall, ctx: &mut Context) {
         request::ApplyWorkspaceEdit::METHOD => {
             workspace::apply_edit_from_server(request.params, ctx)
         }
+        request::SemanticTokensRefesh::METHOD => semantic_tokens::refresh(ctx),
         request::WorkDoneProgressCreate::METHOD => {
             progress::work_done_progress_create(request.params, ctx)
         }

--- a/src/general.rs
+++ b/src/general.rs
@@ -77,7 +77,9 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 }),
                 workspace_folders: Some(false),
                 configuration: Some(true),
-                semantic_tokens: None,
+                semantic_tokens: Some(SemanticTokensWorkspaceClientCapabilities {
+                    refresh_support: Some(true),
+                }),
                 code_lens: None,
                 file_operations: None,
             }),

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -10,6 +10,12 @@ use lsp_types::{
 };
 use url::Url;
 
+pub fn refresh(ctx: &mut Context) -> Result<jsonrpc_core::Value, jsonrpc_core::Error> {
+    let meta = ctx.meta_for_session();
+    ctx.exec(meta, "lsp-semantic-tokens-refresh");
+    Ok(jsonrpc_core::Value::Null)
+}
+
 pub fn tokens_request(meta: EditorMeta, ctx: &mut Context) {
     let req_params = SemanticTokensParams {
         partial_result_params: Default::default(),


### PR DESCRIPTION
~~With the recent addition of the code actions indicator, I realized that semantic tokens could be done in a better way and "just work" instead of having the request on every keystroke.~~

Now just minor changes and the lsp-semantic-tokens-refresh server request implemented.