### PR TITLE
Do not request code actions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 Additions:
- - Show lightbulb in modeline when code actions are available (#538).
+ - Show lightbulb in modeline when code actions are available and `lsp_auto_show_code_actions` is set (#538).
  - Sequences of text edits (like from `lsp-code-actions` or `lsp-formatting`) will create just one undo entry (#533).
  - Fix go-to-defintion for files containing invalid UTF-8 (#535).
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -154,7 +154,7 @@ hook global WinSetOption filetype=rust %{
 ----
 
 * `lsp-rename <new_name>` and `lsp-rename-prompt` commands to rename the symbol under the main cursor.
-* A lightbulb in the mode line whenever code actions are available at the main cursor position
+* If `lsp_auto_show_code_actions` is `true`, a lightbulb in the mode line whenever code actions are available at the main cursor position
 ** To customize the lightbulb, you can override `lsp-show-code-actions` and `lsp-hide-code-actions`
 * `lsp-code-actions` to open a menu to chose a code action to run
 ** To customize the menu, you can override `lsp-perform-code-action`
@@ -267,6 +267,7 @@ kak-lsp's Kakoune integration declares the following options:
 * `lsp_hover_insert_mode_trigger` (str): This option is set to a Kakoune command. When using `lsp-auto-hover-insert-mode-enable`, this command is executed every time the user pauses in insert mode. If the command succeeds, kak-lsp will send a hover-information request for the text selected by the command.
 * `lsp_insert_spaces` (bool): When using `lsp-formatting`, if this option is `true`, kak-lsp will ask the language server to indent with spaces rather than tabs.
 * `lsp_auto_highlight_references` (bool): If this option is `true` then `lsp-highlight-references` is executed every time the user pauses in normal mode.
+* `lsp_auto_show_code_actions` (bool): If this option is `true` then `lsp-code-actions` is executed every time the user pauses in normal mode.
 * `lsp_config` (str): This is a TOML string of the same format as `kak-lsp.toml`, except it only supports one settings:
 ** `[language.<filetype>.settings]`: this works just like the static configuration of the same name in `kak-lsp.toml`, see the section about server-specific configuration. This will override the static configuration of the given language.
 

--- a/test/rust-analyzer-code-actions.sh
+++ b/test/rust-analyzer-code-actions.sh
@@ -11,6 +11,10 @@ roots = ["Cargo.toml"]
 command = "rust-analyzer"
 EOF
 
+cat >> .config/kak/kakrc << EOF
+set-option global lsp_auto_show_code_actions true
+EOF
+
 cat > main.rs << EOF
 enum Test {
     Foo,

--- a/test/rust-analyzer-inlay-code-actions.sh
+++ b/test/rust-analyzer-inlay-code-actions.sh
@@ -11,6 +11,10 @@ roots = ["Cargo.toml"]
 command = "rust-analyzer"
 EOF
 
+cat >> .config/kak/kakrc << EOF
+set-option global lsp_auto_show_code_actions true
+EOF
+
 cat > main.rs << EOF
 enum Test {
     Foo,

--- a/test/typescript-language-server-code-actions.sh
+++ b/test/typescript-language-server-code-actions.sh
@@ -12,6 +12,10 @@ command = "typescript-language-server"
 args = ["--stdio"]
 EOF
 
+cat >> .config/kak/kakrc << EOF
+set-option global lsp_auto_show_code_actions true
+EOF
+
 cat > main.ts << EOF
 class MyClass {
 	doSomething() {


### PR DESCRIPTION
With the default idle_timeout of 50ms we send quite a lot of requests (#429,
#394), in particular with the recent additions to request for code actions
when idle.
When making nontrivial changes that break the build of the kak-lsp
project, the code action requests seem to keep rust-analyzer maxing
out 1-2 CPUs for a while, even causing some lag in the editor UI
(at least with a debug build of kak-lsp).

The lightbulb is not worth the risk of breaking basic functionality
(like go-to-definition), so disable it by default. Add option
lsp_auto_show_code_actions to enable sending requests.
