### PR TITLE
Shorter Semantic Tokens Syntax

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -349,15 +349,12 @@ The syntax for such an entry is
 
 [source,toml]
 ----
-[[semantic_tokens]]
-token = "variable"
-face = "const_variable_declaration"
-modifiers = ["constant", "declaration"]
+"[token][+modifier1[+modifier2]...]" = "face"
 ----
 
-where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `token` and `face` are required.
+where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` or `token` may be omitted. An entry with no token will match any token (but should still have modifiers)
 
-You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entry's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry. +
+You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entry's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry.
 `kak-lsp` will find the most specific matching configuration to apply, where specificity is defined as the number of matching modifiers. If multiple matching entries have the same number of modifiers, the one that was defined last in the configuration wins.
 
 *Example:*
@@ -366,19 +363,10 @@ Assuming the following configuration,
 
 [source,toml]
 ----
-[[semantic_tokens]]
-token = "variable"
-face = "const_variable_declaration"
-modifiers = ["constant", "declaration"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "const_variable"
-modifiers = ["constant"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "variable"
+[semantic_tokens]
+"variable+constant+declaration" = "const_variable_declaration"
+"variable+constant" = "const_variable"
+"variable" = "variable"
 ----
 
 `kak-lsp` will perform these mappings:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -352,7 +352,13 @@ The syntax for such an entry is
 "[token][+modifier1[+modifier2]...]" = "face"
 ----
 
-where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` or `token` may be omitted. An entry with no token will match any token (but should still have modifiers)
+where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and each `modifier` is a modifier name (also reported by the language server).
+
+If the `token` or all `modifier`s are omitted, they will act as "match anything" for their respective category.
+Example:
+- `"variable" = "my_face"` will match any `variable` token, regardless of modifiers
+- `"+readonly" = "my_face"` will match any token that's flagged as `readonly`
+- `"" = "my_face"` will match everything. You should avoid this, as it will result in huge, inefficient highlighter ranges. Use a generic `fill` highlighter from Kakoune instead.
 
 You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entry's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry.
 `kak-lsp` will find the most specific matching configuration to apply, where specificity is defined as the number of matching modifiers. If multiple matching entries have the same number of modifiers, the one that was defined last in the configuration wins.

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -348,49 +348,15 @@ command = "zls"
 # Examples:
 # - TypeScript: https://github.com/microsoft/vscode-languageserver-node/blob/2645fb54ea1e764aff71dee0ecc8aceff3aabf56/client/src/common/semanticTokens.ts#L58
 # - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
-[[semantic_tokens]]
-token = "comment"
-face = "documentation"
-modifiers = ["documentation"]
-
-[[semantic_tokens]]
-token = "comment"
-face = "comment"
-
-[[semantic_tokens]]
-token = "function"
-face = "function"
-
-[[semantic_tokens]]
-token = "keyword"
-face = "keyword"
-
-[[semantic_tokens]]
-token = "namespace"
-face = "module"
-
-[[semantic_tokens]]
-token = "operator"
-face = "operator"
-
-[[semantic_tokens]]
-token = "string"
-face = "string"
-
-[[semantic_tokens]]
-token = "type"
-face = "type"
-
-[[semantic_tokens]]
-token = "variable"
-face = "default+d"
-modifiers = ["readonly"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "default+d"
-modifiers = ["constant"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "variable"
+[semantic_tokens]
+"comment+documentation" = "documentation"
+"comment" = "comment"
+"function" = "function"
+"keyword" = "keyword"
+"namespace" = "module"
+"operator" = "operator"
+"string" = "string"
+"type" = "type"
+"variable+readonly" = "default+d"
+"variable+constant" = "default+d"
+"variable" = "variable"

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -348,6 +348,7 @@ command = "zls"
 # Examples:
 # - TypeScript: https://github.com/microsoft/vscode-languageserver-node/blob/2645fb54ea1e764aff71dee0ecc8aceff3aabf56/client/src/common/semanticTokens.ts#L58
 # - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
+# Syntax: "[token][+modifier1[+modifier2]...]" = "face"
 [semantic_tokens]
 "comment+documentation" = "documentation"
 "comment" = "comment"

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -76,7 +76,7 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
                     .collect();
 
                 let candidates = ctx.config.semantic_tokens.iter().filter(|token_config| {
-                    token_name == token_config.token &&
+                    (token_name == token_config.token || token_config.token.is_empty()) &&
                         // All the config's modifiers must exist on the token for this
                         // config to match.
                         token_config

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,7 +81,16 @@ fn deserialize_semantic_tokens<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    Vec::deserialize(deserializer).map_err(|e| {
+    HashMap::<String, String>::deserialize(deserializer).map(|xs| {
+                xs.into_iter().map(|(k, face)| {
+                    let mut token_mods = k.split('+').map(String::from);
+                    let token = token_mods.next().unwrap_or_default();
+                    let modifiers = token_mods.map(SemanticTokenModifier::from).collect::<Vec<_>>();
+                    SemanticTokenConfig {
+                        token, face, modifiers
+                    }
+                }).collect()
+        }).map_err(|e| {
         D::Error::custom(e.to_string() + "\nSee https://github.com/kak-lsp/kak-lsp#semantic-tokens for the new configuration syntax for semantic tokens\n")
     })
 }


### PR DESCRIPTION
The Syntax is:
```toml
"token+mod1+mod2" = "face"
```

This makes semantic tokens a lot easier to configure, and should have the same expressivity. I know the syntax has already changed at least once, but i feel this improvement is large enough to justify the hassle of upgrading

It also allows for entries without the token field, for when faces should be selected only based on modifiers.