### PR TITLE
Cleanup: remove some unused/redundant code related to #557

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -230,7 +230,7 @@ define-command lsp-hover -docstring "Request hover info for the main cursor posi
     lsp-did-change-and-then lsp-hover-request
 }
 
-define-command -hidden lsp-hover-request -params 0..2 -docstring "Request hover info for the main cursor position" %{
+define-command -hidden lsp-hover-request -docstring "Request hover info for the main cursor position" %{
     nop %sh{ (printf '
 session   = "%s"
 client    = "%s"
@@ -241,9 +241,7 @@ method    = "textDocument/hover"
 [params]
 position.line = %d
 position.column = %d
-style = "%s"
-context = "%s"
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} "$1" "$2" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
 declare-option -hidden str lsp_symbol_kind_completion %{

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -11,7 +11,6 @@ use url::Url;
 
 pub fn text_document_hover(meta: EditorMeta, editor_params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(editor_params.clone()).unwrap();
-    let hover_modal_params = HoverModalParams::deserialize(editor_params).unwrap();
     let req_params = HoverParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
@@ -22,7 +21,7 @@ pub fn text_document_hover(meta: EditorMeta, editor_params: EditorParams, ctx: &
         work_done_progress_params: Default::default(),
     };
     ctx.call::<HoverRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        editor_hover(meta, hover_modal_params.hover_modal, params, result, ctx)
+        editor_hover(meta, None, params, result, ctx)
     });
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -236,17 +236,10 @@ pub struct KakounePosition {
     pub column: u32, // in bytes, not chars!!!
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct HoverModal {
     pub context: String,
     pub do_after: String,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HoverModalParams {
-    pub hover_modal: Option<HoverModal>,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Cleanup: remove some unused/redundant code related to #557

- We don't ever use `HoverModalParams` from the editor so we should just remove the ability to pass in parameters to kak-lsp. We never need to _use_ the serialization as of now. 
- `style` is no longer used
- `context` comes with `struct HoverModalParams` so it can be removed
- We never need to serialize/deserialize the struct `HoverModal`

If we every find a use for these things they can be added again.

