### PR TITLE
Feature: Allow to show hover info in scratch buffer

### DIFF
--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -236,8 +236,7 @@ fn editor_next_or_prev_for_details(
         work_done_progress_params: Default::default(),
     };
 
-    // This context is shown at the top of the modal.
-    let context = format!(
+    let modal_heading = format!(
         "line {}:{}:{{+b@KindAndName}}{:?} {}{{KindAndName}} \
             (Press 'g' to goto this position. Press any other key to continue)",
         symbol_position.line,
@@ -263,7 +262,10 @@ fn editor_next_or_prev_for_details(
     ctx.call::<HoverRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         editor_hover(
             meta,
-            Some(HoverModal { context, do_after }),
+            HoverType::Modal {
+                modal_heading,
+                do_after,
+            },
             PositionParams {
                 position: symbol_position,
             },

--- a/src/types.rs
+++ b/src/types.rs
@@ -156,6 +156,12 @@ pub struct PositionParams {
     pub position: KakounePosition,
 }
 
+#[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HoverDetails {
+    pub hover_fifo: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallHierarchyParams {
@@ -228,10 +234,16 @@ pub struct KakounePosition {
     pub column: u32, // in bytes, not chars!!!
 }
 
-#[derive(Clone, Debug)]
-pub struct HoverModal {
-    pub context: String,
-    pub do_after: String,
+#[derive(PartialEq)]
+pub enum HoverType {
+    Normal,
+    Modal {
+        modal_heading: String,
+        do_after: String,
+    },
+    InfoInHoverClient {
+        fifo: String,
+    },
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
![info_in_hoverclient](https://user-images.githubusercontent.com/638477/142416931-f4379424-91fb-481d-ae52-5034b85b8413.png)

Sometimes the hover information sent to kakoune by kak-lsp is either
very long or has rich markdown (or both). The hover info is shown in an
info box which can be very difficult to read.

Add a new command `lsp-hover-in-hover-client` which will open the hover
information in a new client. You also get the benefit of syntax
highlighting as the codeblocks are enclosed within three ticks
(with the language name) and kak understands that.

The user can continue issuing `lsp-hover-in-hover-client` commands
and they will appear in the `hoverclient`. The focus will not
shift from the window in which the user was typing in.

This feature can be very visually appealing if you use kakoune
with something like tmux however it will work properly even without it.

If a `hoverclient` does not exist it will be created via `new`.

**Try this out**

If you are using rust-analyzer then place your cursor over any
of the characters of `fn` or any of the characters of `let` and
issue the above command (**keyboard shortcut is _lsp_ H**).

You will see great documentation for `fn` / `let`.

**Why not just use goto definition?**

Many languages have the documentation for a function above it.
But you cannot goto definition in all situations. For instance, you
cannot goto definition on the `let` statement in Rust.

This feature can be especially useful for [ocaml lsp server](https://github.com/ocaml/ocaml-lsp) to be able to
see long signatures. In my testing other LSPs that give you
a lot of hover info become more usable.