### PR TITLE
add racket lsp config

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -240,6 +240,12 @@ roots = ["DESCRIPTION", ".git", ".hg"]
 command = "R"
 args = ["--slave", "-e", "languageserver::run()"]
 
+[language.racket]
+filetypes = ["racket"]
+roots = ["info.rkt"]
+command = "racket"
+args = ["-l", "racket-langserver"]
+
 [language.reason]
 filetypes = ["reason"]
 roots = ["package.json", "Makefile", ".git", ".hg"]


### PR DESCRIPTION
It works as intended.

![image](https://user-images.githubusercontent.com/20123683/142761992-bba1062d-da4f-485e-91f9-0a5071af5573.png)

The `info.rkt` file is equivalent of `
CMakeLists.txt` or `Cargo.toml`. It indicates the root of projects.
https://docs.racket-lang.org/raco/info_rkt.html


