### PR TITLE
Show hover information in a scratch buffer v2

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -130,7 +130,8 @@ Either way you get:
 
 * completions
 * `lsp-definition` command to go to definition, mapped to `gd` by default
-* `lsp-hover` command to show hover info (including relevant diagnostics when available)
+* `lsp-hover` command to show hover info (including relevant diagnostics when available) in the info box.
+* `lsp-hover-buffer` command to show hover info in a scratch buffer.
 ** to automatically show hover when you move around, use `lsp-auto-hover-enable`
 ** to show hover anchored to hovered position, use `set global lsp_hover_anchor true`
 ** to exclude diagnostics, use `set-option global lsp_show_hover_format 'printf %s "${lsp_info}"'`

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -280,6 +280,13 @@ position.column = %d
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "$maybe_hover_fifo" ${kak_cursor_line} ${kak_cursor_column} | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
+declare-option -hidden str lsp_hover_fifo %sh{
+    tmpdir=$(mktemp -q -d -t 'lsp-hover-client.XXXXXX' 2>/dev/null || mktemp -q -d)
+    output="$tmpdir/fifo"
+    mkfifo "$output"
+    echo "$output"
+}
+
 declare-option -hidden str lsp_symbol_kind_completion %{
     symbol_kinds="\
     File Module Namespace Package Class Method Property Field Constructor Enum Interface
@@ -1957,13 +1964,4 @@ define-command lsp-goto-next-match -docstring 'DEPRECATED: use lsp-next-location
 
 define-command lsp-goto-previous-match -docstring 'DEPRECATED: use lsp-previous-location. Jump to the previous goto match' %{
     lsp-previous-location '*goto*'
-}
-
-declare-option -hidden str lsp_hover_fifo
-
-set-option global lsp_hover_fifo %sh{
-    tmpdir=$(mktemp -q -d -t 'lsp-hover-client.XXXXXX' 2>/dev/null || mktemp -q -d)
-    output="$tmpdir/fifo"
-    mkfifo "$output"
-    echo "$output"
 }

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -286,6 +286,7 @@ declare-option -hidden str lsp_hover_fifo %sh{
     mkfifo "$output"
     echo "$output"
 }
+hook -always -group lsp global KakEnd .* %{nop %sh{rm -f "$kak_opt_lsp_hover_fifo"; rmdir "${kak_opt_lsp_hover_fifo%/*}"}}
 
 declare-option -hidden str lsp_symbol_kind_completion %{
     symbol_kinds="\

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -255,8 +255,18 @@ define-command lsp-hover -docstring "Request hover info for the main cursor posi
     lsp-did-change-and-then lsp-hover-request
 }
 
-define-command -hidden lsp-hover-request -docstring "Request hover info for the main cursor position" %{
-    nop %sh{ (printf '
+define-command lsp-hover-in-hover-client -docstring "Request hover info for the main cursor position in a separate client" %{
+    lsp-did-change-and-then "lsp-hover-request in_hover_client"
+}
+
+define-command -hidden lsp-hover-request -params 0..1 -docstring "Request hover info for the main cursor position" %{
+    nop %sh{
+        maybe_hover_fifo=""
+        if [ "$1" = "in_hover_client" ]; then
+            maybe_hover_fifo="hoverFifo = \"${kak_opt_lsp_hover_fifo}\""
+        fi
+
+        (printf '
 session   = "%s"
 client    = "%s"
 buffile   = "%s"
@@ -264,9 +274,10 @@ filetype  = "%s"
 version   = %d
 method    = "textDocument/hover"
 [params]
+%s
 position.line = %d
 position.column = %d
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "$maybe_hover_fifo" ${kak_cursor_line} ${kak_cursor_column} | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
 declare-option -hidden str lsp_symbol_kind_completion %{
@@ -1528,6 +1539,7 @@ map global lsp d '<esc>: lsp-definition<ret>'              -docstring 'go to def
 map global lsp e '<esc>: lsp-diagnostics<ret>'             -docstring 'list project errors, info, hints and warnings'
 map global lsp f '<esc>: lsp-formatting<ret>'              -docstring 'format buffer'
 map global lsp h '<esc>: lsp-hover<ret>'                   -docstring 'show info for current position'
+map global lsp H '<esc>: lsp-hover-in-hover-client<ret>'   -docstring 'show info for current position in separate client'
 map global lsp i '<esc>: lsp-implementation<ret>'          -docstring 'go to implementation'
 map global lsp j '<esc>: lsp-outgoing-calls<ret>'          -docstring 'list outgoing call for function at cursor'
 map global lsp k '<esc>: lsp-incoming-calls<ret>'          -docstring 'list incoming call for function at cursor'
@@ -1945,4 +1957,13 @@ define-command lsp-goto-next-match -docstring 'DEPRECATED: use lsp-next-location
 
 define-command lsp-goto-previous-match -docstring 'DEPRECATED: use lsp-previous-location. Jump to the previous goto match' %{
     lsp-previous-location '*goto*'
+}
+
+declare-option -hidden str lsp_hover_fifo
+
+set-option global lsp_hover_fifo %sh{
+    tmpdir=$(mktemp -q -d -t 'lsp-hover-client.XXXXXX' 2>/dev/null || mktemp -q -d)
+    output="$tmpdir/fifo"
+    mkfifo "$output"
+    echo "$output"
 }

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1492,9 +1492,14 @@ define-command lsp-inlay-diagnostics-disable -params 1 -docstring "lsp-inlay-dia
     remove-highlighter "%arg{1}/lsp_diagnostics"
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
-define-command lsp-auto-hover-enable -docstring "Enable auto-requesting hover info for current position" %{
-    hook -group lsp-auto-hover global NormalIdle .* %{
-        lsp-hover
+define-command lsp-auto-hover-enable -params 0..1 -client-completion \
+    -docstring "lsp-auto-hover-enable [<client>]: enable auto-requesting hover info for current position
+
+If a client is given, show hover in a scratch buffer in that client instead of the info box" %{
+    evaluate-commands %sh{
+        hover=lsp-hover
+        [ $# -eq 1 ] && hover="lsp-hover-buffer $1"
+        printf %s "hook -group lsp-auto-hover global NormalIdle .* %{ $hover }"
     }
 }
 
@@ -1502,11 +1507,20 @@ define-command lsp-auto-hover-disable -docstring "Disable auto-requesting hover 
     remove-hooks global lsp-auto-hover
 }
 
-define-command lsp-auto-hover-insert-mode-enable -docstring "Enable auto-requesting hover info for current function in insert mode" %{
-    hook -group lsp-auto-hover-insert-mode global InsertIdle .* %{ try %{ evaluate-commands -draft %{
-        evaluate-commands %opt{lsp_hover_insert_mode_trigger}
-        lsp-hover
-    }}}
+define-command lsp-auto-hover-insert-mode-enable -params 0..1 -client-completion \
+    -docstring "lsp-auto-hover-enable [<client>]: enable auto-requesting hover info for current function in insert mode
+
+If a client is given, show hover in a scratch buffer in that client instead of the info box" %{
+    evaluate-commands %sh{
+        hover=lsp-hover
+        [ $# -eq 1 ] && hover="lsp-hover-buffer $1"
+        printf %s "hook -group lsp-auto-hover-insert-mode global InsertIdle .* %{
+            try %{ evaluate-commands -draft %{
+                evaluate-commands %opt{lsp_hover_insert_mode_trigger}
+                $hover
+            }}
+        }"
+    }
 }
 
 define-command lsp-auto-hover-insert-mode-disable -docstring "Disable auto-requesting hover info for current function in insert mode" %{

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -281,7 +281,7 @@ position.column = %d
 }
 
 declare-option -hidden str lsp_hover_fifo %sh{
-    tmpdir=$(mktemp -q -d -t 'lsp-hover-client.XXXXXX' 2>/dev/null || mktemp -q -d)
+    tmpdir=$(mktemp -q -d -t 'kak-lsp-hover-buffer.XXXXXX' 2>/dev/null || mktemp -q -d)
     output="$tmpdir/fifo"
     mkfifo "$output"
     echo "$output"

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -275,8 +275,7 @@ fn editor_next_or_prev_for_details(
         work_done_progress_params: Default::default(),
     };
 
-    // This context is shown at the top of the modal.
-    let context = format!(
+    let modal_heading = format!(
         "line {}:{}:{{+b@KindAndName}}{:?} {}{{KindAndName}} \
             (Press 'g' to goto this position. Press any other key to continue)",
         symbol_position.line,
@@ -302,7 +301,10 @@ fn editor_next_or_prev_for_details(
     ctx.call::<HoverRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         editor_hover(
             meta,
-            Some(HoverModal { context, do_after }),
+            HoverType::Modal {
+                modal_heading,
+                do_after,
+            },
             PositionParams {
                 position: symbol_position,
             },

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -276,7 +276,7 @@ fn editor_next_or_prev_for_details(
     };
 
     let modal_heading = format!(
-        "line {}:{}:{{+b@KindAndName}}{:?} {}{{KindAndName}} \
+        "line {}:{}:{{+b@InfoHeader}}{:?} {}{{InfoHeader}} \
             (Press 'g' to goto this position. Press any other key to continue)",
         symbol_position.line,
         symbol_position.column,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -173,10 +173,10 @@ fn show_hover_modal(
         diagnostics.replace("§", "§§"),
     );
     let wrapped_command = formatdoc!(
-        "eval %§
-                 {}
-                 {}
-             §",
+        "evaluate-commands %§
+             {}
+             {}
+         §",
         command.replace("§", "§§"),
         do_after.replace("§", "§§")
     );
@@ -200,26 +200,24 @@ fn show_hover_in_hover_client(
     });
 
     let command = formatdoc!(
-        "
-        %[
-            edit! -existing -readonly -fifo %opt[lsp_hover_fifo] *hover*
-            set buffer=*hover* filetype markdown
-        ]"
+        "%[
+             edit! -existing -readonly -fifo %opt[lsp_hover_fifo] *hover*
+             set-option buffer=*hover* filetype markdown
+         ]"
     );
 
     let client = meta.client.clone().unwrap_or_default();
     let command = formatdoc!(
-        "
-        try %[
-            eval -client {} {}
-        ] catch %[
-            new %[
-                rename-client {}
-                eval {}
-                addhl -override window/wrap wrap
-                focus {}
-            ]
-        ]",
+        "try %[
+             evaluate-commands -client {} {}
+         ] catch %[
+             new %[
+                 rename-client {}
+                 evaluate-commands {}
+                 add-highlighter -override window/wrap wrap
+                 focus {}
+             ]
+         ]",
         &hover_client,
         command,
         &hover_client,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -223,11 +223,10 @@ fn show_hover_in_hover_client(
         fs::write(hover_fifo, contents.as_bytes()).unwrap();
     });
 
-    let command = formatdoc!(
-        "%[
-             edit! -existing -readonly -fifo %opt[lsp_hover_fifo] *hover*
-             set-option buffer=*hover* filetype {}
-         ]",
+    let command = format!(
+        "%[ edit! -existing -readonly -fifo %opt[lsp_hover_fifo] *hover*; \
+             set-option buffer=*hover* filetype {} \
+          ]",
         if is_markdown { "markdown" } else { "''" },
     );
 

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use crate::context::*;
 use crate::markup::*;
 use crate::position::*;
@@ -9,8 +11,17 @@ use lsp_types::*;
 use serde::Deserialize;
 use url::Url;
 
-pub fn text_document_hover(meta: EditorMeta, editor_params: EditorParams, ctx: &mut Context) {
-    let params = PositionParams::deserialize(editor_params).unwrap();
+pub fn text_document_hover(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let maybe_hover_fifo = HoverDetails::deserialize(params.clone())
+        .unwrap()
+        .hover_fifo;
+
+    let hover_type = match maybe_hover_fifo {
+        Some(fifo) => HoverType::InfoInHoverClient { fifo },
+        None => HoverType::Normal,
+    };
+
+    let params = PositionParams::deserialize(params).unwrap();
     let req_params = HoverParams {
         text_document_position_params: TextDocumentPositionParams {
             text_document: TextDocumentIdentifier {
@@ -21,13 +32,13 @@ pub fn text_document_hover(meta: EditorMeta, editor_params: EditorParams, ctx: &
         work_done_progress_params: Default::default(),
     };
     ctx.call::<HoverRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        editor_hover(meta, None, params, result, ctx)
+        editor_hover(meta, hover_type, params, result, ctx)
     });
 }
 
 pub fn editor_hover(
     meta: EditorMeta,
-    maybe_hover_modal: Option<HoverModal>,
+    hover_type: HoverType,
     params: PositionParams,
     result: Option<Hover>,
     ctx: &mut Context,
@@ -90,7 +101,7 @@ pub fn editor_hover(
         .get(&ctx.language_id)
         .and_then(|l| l.workaround_server_sends_plaintext_labeled_as_markdown)
         .unwrap_or(false);
-    let mut contents = match result {
+    let contents = match result {
         None => "".to_string(),
         Some(result) => match result.contents {
             HoverContents::Scalar(contents) => {
@@ -105,43 +116,112 @@ pub fn editor_hover(
                     FACE_INFO_RULE, FACE_INFO_DEFAULT
                 )),
             HoverContents::Markup(contents) => match contents.kind {
-                MarkupKind::Markdown => markdown_to_kakoune_markup(contents.value, force_plaintext),
+                MarkupKind::Markdown => {
+                    if let HoverType::InfoInHoverClient { .. } = hover_type {
+                        contents.value
+                    } else {
+                        markdown_to_kakoune_markup(contents.value, force_plaintext)
+                    }
+                }
                 MarkupKind::PlainText => contents.value,
             },
         },
     };
 
-    if contents.is_empty() && diagnostics.is_empty() && maybe_hover_modal.is_none() {
-        return;
-    }
+    match hover_type {
+        HoverType::Normal => {
+            if contents.is_empty() && diagnostics.is_empty() {
+                return;
+            }
 
-    let anchor_or_style = if let Some(hover_modal) = maybe_hover_modal.as_ref() {
-        contents = format!("{}\n---\n{}", hover_modal.context, contents);
-        "modal".to_string()
-    } else {
-        format!("{}", params.position)
+            let command = format!(
+                "lsp-show-hover {} %§{}§ %§{}§",
+                params.position,
+                contents.replace("§", "§§"),
+                diagnostics.replace("§", "§§"),
+            );
+            ctx.exec(meta, command);
+        }
+        HoverType::Modal {
+            modal_heading,
+            do_after,
+        } => {
+            show_hover_modal(meta, ctx, modal_heading, do_after, contents, diagnostics);
+        }
+        HoverType::InfoInHoverClient { fifo } => {
+            show_hover_in_hover_client(meta, ctx, fifo, contents);
+        }
     };
+}
 
-    let mut command = format!(
-        "lsp-show-hover {} %§{}§ %§{}§",
-        anchor_or_style,
+fn show_hover_modal(
+    meta: EditorMeta,
+    ctx: &Context,
+    modal_heading: String,
+    do_after: String,
+    contents: String,
+    diagnostics: String,
+) {
+    let contents = format!("{}\n---\n{}", modal_heading, contents);
+    let command = format!(
+        "lsp-show-hover modal %§{}§ %§{}§",
         contents.replace("§", "§§"),
-        diagnostics.replace("§", "§§")
+        diagnostics.replace("§", "§§"),
     );
-
-    // Wrap if we're using a HoverModal
-    if let Some(hover_modal) = maybe_hover_modal {
-        command = formatdoc!(
-            "eval %§
+    let wrapped_command = formatdoc!(
+        "eval %§
                  {}
                  {}
              §",
-            command.replace("§", "§§"),
-            hover_modal.do_after.replace("§", "§§")
-        );
+        command.replace("§", "§§"),
+        do_after.replace("§", "§§")
+    );
+    ctx.exec(meta, wrapped_command);
+}
+
+fn show_hover_in_hover_client(
+    meta: EditorMeta,
+    ctx: &Context,
+    hover_fifo: String,
+    contents: String,
+) {
+    if contents.is_empty() {
+        return;
     }
 
+    let handle = std::thread::spawn(move || {
+        // Note that we don't show diagnostics in the hover client
+        fs::write(hover_fifo, contents.as_bytes()).unwrap();
+    });
+
+    let command = formatdoc!(
+        "
+        %[
+            edit! -existing -readonly -fifo %opt[lsp_hover_fifo] *hover*
+            set buffer=*hover* filetype markdown
+        ]"
+    );
+
+    let client = meta.client.clone().unwrap_or_default();
+    let command = formatdoc!(
+        "
+        try %[
+            eval -client hoverclient {}
+        ] catch %[
+            new %[
+                rename-client hoverclient
+                eval {}
+                addhl -override window/wrap wrap
+                focus {}
+            ]
+        ]",
+        command,
+        command,
+        client
+    );
+
     ctx.exec(meta, command);
+    handle.join().unwrap();
 }
 
 trait PlainText {

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -238,7 +238,7 @@ fn show_hover_in_hover_client(
              new %[
                  rename-client {}
                  evaluate-commands {}
-                 add-highlighter -override window/wrap wrap
+                 add-highlighter -override window/wrap wrap -word
                  focus {}
              ]
          ]",

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -224,7 +224,7 @@ fn show_hover_in_hover_client(
     });
 
     let command = format!(
-        "%[ edit! -existing -readonly -fifo %opt[lsp_hover_fifo] *hover*; \
+        "%[ edit! -existing -fifo %opt[lsp_hover_fifo] *hover*; \
              set-option buffer=*hover* filetype {} \
           ]",
         if is_markdown { "markdown" } else { "''" },

--- a/src/types.rs
+++ b/src/types.rs
@@ -161,6 +161,7 @@ pub struct PositionParams {
 #[serde(rename_all = "camelCase")]
 pub struct HoverDetails {
     pub hover_fifo: Option<String>,
+    pub hover_client: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -245,6 +246,7 @@ pub enum HoverType {
     },
     InfoInHoverClient {
         fifo: String,
+        client: String,
     },
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,6 +157,12 @@ pub struct PositionParams {
     pub position: KakounePosition,
 }
 
+#[derive(Clone, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HoverDetails {
+    pub hover_fifo: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallHierarchyParams {
@@ -230,10 +236,16 @@ pub struct KakounePosition {
     pub column: u32, // in bytes, not chars!!!
 }
 
-#[derive(Clone, Debug)]
-pub struct HoverModal {
-    pub context: String,
-    pub do_after: String,
+#[derive(PartialEq)]
+pub enum HoverType {
+    Normal,
+    Modal {
+        modal_heading: String,
+        do_after: String,
+    },
+    InfoInHoverClient {
+        fifo: String,
+    },
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This is built on top of https://github.com/kak-lsp/kak-lsp/pull/564,
with review comments address, and some extra features.

The most important behavior change is that the new binding (lsp H)
by default shows the `*hover*` buffer in the current client.
I'm not super sure about that yet, but it seems like the smallest
common denominator.
