### PR TITLE
Allow whitespace in gutter signs

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -52,7 +52,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         .iter()
         .map(|x| {
             format!(
-                "{}|{}",
+                "'{}|{}'",
                 x.range.start.line + 1,
                 match x.severity {
                     Some(DiagnosticSeverity::ERROR) => {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -151,7 +151,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
          set buffer lsp_diagnostic_info_count {}; \
          set buffer lsp_diagnostic_warning_count {}; \
          set buffer lsp_errors {} {}; \
-         eval \"set buffer lsp_error_lines {} {} '0| '\"; \
+         eval \"set buffer lsp_error_lines {} {} '0|%opt[lsp_diagnostic_line_error_sign]'\"; \
          set buffer lsp_diagnostics {} {}",
         error_count,
         hint_count,

--- a/test/clangd-diagnostic-gutter.sh
+++ b/test/clangd-diagnostic-gutter.sh
@@ -20,3 +20,9 @@ test_tmux_kak_start main.c
 test_tmux capture-pane -p | sed 2q
 # CHECK: {{W }}void main(int argc, char** argv) {}
 # CHECK: {{ X}}syntax error
+
+test_tmux send-keys %:comment-line Enter
+test_sleep
+test_tmux capture-pane -p | sed 2q
+# CHECK: {{  }}// void main(int argc, char** argv) {}
+# CHECK: {{  }}// syntax error

--- a/test/clangd-diagnostic-gutter.sh
+++ b/test/clangd-diagnostic-gutter.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# REQUIRES: command -v clangd
+
+. test/lib.sh
+
+cat >> .config/kak/kakrc << EOF
+set-option global lsp_diagnostic_line_error_sign   ' X'
+set-option global lsp_diagnostic_line_hint_sign    '¿ '
+set-option global lsp_diagnostic_line_info_sign    '¡ '
+set-option global lsp_diagnostic_line_warning_sign 'W '
+EOF
+
+cat > main.c << EOF
+void main(int argc, char** argv) {}
+syntax error
+EOF
+
+test_tmux_kak_start main.c
+test_tmux capture-pane -p | sed 2q
+# CHECK: {{W }}void main(int argc, char** argv) {}
+# CHECK: {{ X}}syntax error


### PR DESCRIPTION
By surrounding the different line-specs with single quotes, we enable the use of whitespace for the `lsp_diagnostic_line_error_sign`, `lsp_diagnostic_line_hint_sign`, `lsp_diagnostic_line_info_sign`, `lsp_diagnostic_line_warning_sign` options.

This is necessary to allow for some breathing room between the lsp-error and other gutters (eg. line-numbers).
As an example use-case: I use nerd-font icons as my symbols, but they are wider than an actual character and thus I need to add a whitespace character afterwards. Otherwise the icon overlaps the line-numbers