### PR TITLE
Add support for custom texlab commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_repr",
  "slog",
  "slog-scope",
  "sloggers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ropey = "1.2.0"
 serde = "1.0.112"
 serde_derive = "1.0.112"
 serde_json = "1.0.55"
+serde_repr = "0.1.7"
 slog = { version = "2.5.2", features = ["release_max_level_debug"] }
 slog-scope = "4.3.0"
 sloggers = "2.0.2"

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1127,6 +1127,45 @@ method    = "rust-analyzer/inlayHints"
 ' "${kak_session}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
+# texlab extensions
+
+define-command texlab-forward-search -docstring "Request SyncTeX Forward Search for current line from the texlab language server
+
+This will focus the current line in your PDF viewer, starting one if necessary.
+To configure the PDF viewer, use texlab's options 'forwardSearch.executable' and 'forwardSearch.args'." %{
+    lsp-did-change-and-then texlab-forward-search-request
+}
+
+define-command -hidden texlab-forward-search-request %{
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "textDocument/forwardSearch"
+[params.position]
+line      = %d
+column    = %d
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
+}
+
+define-command texlab-build -docstring "Ask the texlab language server to build the LaTeX document" %{
+    lsp-did-change-and-then texlab-build-request
+}
+
+define-command -hidden texlab-build-request %{
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "textDocument/build"
+[params]
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
+}
+
 # semantic tokens
 
 define-command lsp-semantic-tokens -docstring "lsp-semantic-tokens: Request semantic tokens" %{

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -329,6 +329,14 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
             rust_analyzer::inlay_hints(meta, params, ctx);
         }
 
+        // texlab
+        texlab::Build::METHOD => {
+            texlab::build(meta, params, ctx);
+        }
+        texlab::ForwardSearch::METHOD => {
+            texlab::forward_search(meta, params, ctx);
+        }
+
         _ => {
             warn!("Unsupported method: {}", method);
         }

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -15,3 +15,4 @@ pub mod rename;
 pub mod rust_analyzer;
 pub mod semantic_tokens;
 pub mod signature_help;
+pub mod texlab;

--- a/src/language_features/texlab.rs
+++ b/src/language_features/texlab.rs
@@ -1,0 +1,107 @@
+use crate::context::Context;
+use crate::position::get_lsp_position;
+use crate::types::{EditorMeta, EditorParams};
+use crate::PositionParams;
+use lsp_types::request::Request;
+use lsp_types::TextDocumentIdentifier;
+use lsp_types::TextDocumentPositionParams;
+use lsp_types::Url;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::fmt;
+
+pub enum ForwardSearch {}
+
+impl Request for ForwardSearch {
+    type Params = TextDocumentPositionParams;
+    type Result = ForwardSearchResult;
+    const METHOD: &'static str = "textDocument/forwardSearch";
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ForwardSearchResult {
+    status: ForwardSearchStatus,
+}
+
+#[derive(Serialize_repr, Deserialize_repr, Debug)]
+#[repr(i32)]
+pub enum ForwardSearchStatus {
+    Success = 0,
+    Error = 1,
+    Failure = 2,
+    Unconfigured = 3,
+}
+
+impl fmt::Display for ForwardSearchResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Forward Search {:?} (texlab)", self.status)
+    }
+}
+
+pub fn forward_search(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params = PositionParams::deserialize(params).unwrap();
+    let req_params = TextDocumentPositionParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+    };
+    ctx.call::<ForwardSearch, _>(meta, req_params, move |ctx, meta, response| {
+        forward_search_response(meta, response, ctx)
+    });
+}
+
+pub fn forward_search_response(meta: EditorMeta, result: ForwardSearchResult, ctx: &mut Context) {
+    let command = format!("echo {}", result);
+    ctx.exec(meta, command);
+}
+
+pub enum Build {}
+
+impl Request for Build {
+    type Params = BuildTextDocumentParams;
+    type Result = BuildResult;
+    const METHOD: &'static str = "textDocument/build";
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildTextDocumentParams {
+    text_document: TextDocumentIdentifier,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BuildResult {
+    status: BuildStatus,
+}
+
+#[derive(Serialize_repr, Deserialize_repr, Debug)]
+#[repr(i32)]
+pub enum BuildStatus {
+    Success = 0,
+    Error = 1,
+    Failure = 2,
+    Cancelled = 3,
+}
+
+impl fmt::Display for BuildResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Build {:?} (texlab)", self.status)
+    }
+}
+
+pub fn build(meta: EditorMeta, _params: EditorParams, ctx: &mut Context) {
+    let req_params = BuildTextDocumentParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+    };
+    ctx.call::<Build, _>(meta, req_params, move |ctx, meta, response| {
+        build_response(meta, response, ctx)
+    });
+}
+
+pub fn build_response(meta: EditorMeta, result: BuildResult, ctx: &mut Context) {
+    let command = format!("echo {}", result);
+    ctx.exec(meta, command);
+}


### PR DESCRIPTION
New commands:
 - `texlab-build` - request `textDocument/build` from texlab
 - `texlab-forward-search` - request `textDocument/forwardSearch` from texlab

I implemented the commands based on the language_features modules of
rust-analyzer and ccls.

I can't confirm whether these changes are correct, since the master branch of kak-lsp currently crashes for me with texlab.

I need to file an issue for that and investigate.

I just configured kak and kak-lsp today and well in love with kakoune's simple, yet powerful featureset.
Therefore I am neither particulary experienced with kakoune, nor with this codebase.
Any help is appreciated.