### PR TITLE
Implement textDocument/selectionRange

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -142,6 +142,8 @@ Either way you get:
 * `lsp-references` command to find references to the symbol under the main cursor, mapped to `gr` by default
 ** for the previous five commands, the `\*goto*` buffer has filetype `lsp-goto`, so you can press `<ret>` on a line or use the `lsp-jump` command
 * `lsp-find-error` command to jump to the next or previous error in the current file
+- `lsp-selection-range` command to quickly select interesting ranges around selections.
+  - `lsp-selection-range-select` to navigate ranges fetched by `lsp-selection-range`.
 * `lsp-next-location` and `lsp-previous-location` to jump to the next or previous location listed in a buffer with the `lsp-goto` filetype. These also work for buffers `\*grep*`, `\*lint*` and `\*make*`
 * `lsp-highlight-references` command to highlight all references to the symbol under the main cursor in the current buffer with the `Reference` face (which is equal to the `MatchingChar` face by default)
 * `lsp-document-symbol` command to list the current buffer's symbols
@@ -208,6 +210,7 @@ map global user l %{: enter-user-mode lsp<ret>} -docstring "LSP mode"
 | o | lsp-workspace-symbol-incr
 | n | lsp-find-error
 | p | lsp-find-error --previous
+| v | lsp-selection-range
 | y | lsp-type-definition
 | 9 | lsp-hover-previous-function
 | 0 | lsp-hover-next-function

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::context::*;
 use crate::diagnostics;
 use crate::general;
-use crate::language_features::*;
+use crate::language_features::{selection_range, *};
 use crate::language_server_transport;
 use crate::progress;
 use crate::text_sync::*;
@@ -256,6 +256,9 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         }
         notification::WorkDoneProgressCancel::METHOD => {
             progress::work_done_progress_cancel(meta, params, ctx);
+        }
+        request::SelectionRangeRequest::METHOD => {
+            selection_range::text_document_selection_range(meta, params, &mut ctx);
         }
         request::SignatureHelpRequest::METHOD => {
             signature_help::text_document_signature_help(meta, params, &mut ctx);

--- a/src/general.rs
+++ b/src/general.rs
@@ -237,7 +237,9 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                     data_support: None,
                 }),
                 folding_range: None,
-                selection_range: None,
+                selection_range: Some(SelectionRangeClientCapabilities {
+                    dynamic_registration: None,
+                }),
                 semantic_tokens: Some(SemanticTokensClientCapabilities {
                     dynamic_registration: Some(false),
                     requests: SemanticTokensClientCapabilitiesRequests {

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -13,6 +13,7 @@ pub mod hover;
 pub mod range_formatting;
 pub mod rename;
 pub mod rust_analyzer;
+pub mod selection_range;
 pub mod semantic_tokens;
 pub mod signature_help;
 pub mod texlab;

--- a/src/language_features/selection_range.rs
+++ b/src/language_features/selection_range.rs
@@ -1,0 +1,169 @@
+use crate::context::*;
+use crate::position::*;
+use crate::types::*;
+use indoc::formatdoc;
+use itertools::Itertools;
+use lsp_types::request::*;
+use lsp_types::*;
+use serde::Deserialize;
+use url::Url;
+
+pub fn text_document_selection_range(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params = SelectionRangePositionParams::deserialize(params).unwrap();
+
+    let selections: Vec<KakouneRange> = params
+        .selections_desc
+        .split_ascii_whitespace()
+        .into_iter()
+        .map(|desc| {
+            let mut parts = desc.split(',');
+            let mut convert = || {
+                let coords = parts.next().unwrap();
+                let mut coords = coords.split('.');
+                KakounePosition {
+                    line: coords.next().unwrap().parse().ok().unwrap(),
+                    column: coords.next().unwrap().parse().ok().unwrap(),
+                }
+            };
+            let anchor = convert();
+            let cursor = convert();
+            if anchor < cursor {
+                KakouneRange {
+                    start: anchor,
+                    end: cursor,
+                }
+            } else {
+                KakouneRange {
+                    start: cursor,
+                    end: anchor,
+                }
+            }
+        })
+        .collect();
+
+    let is_cursor_left_of_anchor = params.position == selections[0].start;
+
+    let document = ctx.documents.get(&meta.buffile).unwrap();
+    let cursor_positions = selections
+        .iter()
+        .map(|range| {
+            let cursor = if is_cursor_left_of_anchor {
+                &range.start
+            } else {
+                &range.end
+            };
+            kakoune_position_to_lsp(cursor, &document.text, ctx.offset_encoding)
+        })
+        .collect();
+
+    let req_params = SelectionRangeParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        positions: cursor_positions,
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    ctx.call::<SelectionRangeRequest, _>(
+        meta,
+        req_params,
+        move |ctx: &mut Context, meta, result| {
+            editor_selection_range(result, selections, is_cursor_left_of_anchor, meta, ctx);
+        },
+    );
+}
+
+fn editor_selection_range(
+    result: Option<Vec<SelectionRange>>,
+    selections: Vec<KakouneRange>,
+    is_cursor_left_of_anchor: bool,
+    meta: EditorMeta,
+    ctx: &mut Context,
+) {
+    let selection_ranges = match result {
+        Some(selection_ranges) => selection_ranges,
+        None => return,
+    };
+
+    let document = ctx.documents.get(&meta.buffile).unwrap();
+    // We get a list of ranges of parent nodes for each Kakoune selection.  The UI wants to
+    // select parent nodes of all Kakoune selections at once.  This means we want to have a
+    // list where each entry updates all selections.  As first step, convert to a matrix where
+    // the first dimension is the parent index, and the second dimension is the Kakoune selection.
+    let mut transposed_selection_ranges: Vec<Vec<Option<KakouneRange>>> = Vec::new();
+    for (sel_idx, sel_range) in selection_ranges.iter().enumerate() {
+        let mut cur = sel_range;
+        let mut i = 0;
+        loop {
+            let range = {
+                let range = lsp_range_to_kakoune(&cur.range, &document.text, ctx.offset_encoding);
+                if is_cursor_left_of_anchor {
+                    KakouneRange {
+                        start: range.end,
+                        end: range.start,
+                    }
+                } else {
+                    range
+                }
+            };
+            if i == transposed_selection_ranges.len() {
+                transposed_selection_ranges.push(vec![None; selection_ranges.len()]);
+            }
+            transposed_selection_ranges[i][sel_idx] = Some(range);
+            i += 1;
+            match cur.parent.as_deref() {
+                Some(parent) => cur = parent,
+                None => break,
+            }
+        }
+    }
+
+    let transposed_selection_ranges = transposed_selection_ranges
+        .iter()
+        .map(|sel_ranges| {
+            format!(
+                "'{}'",
+                &sel_ranges
+                    .iter()
+                    .filter_map(|s| s.map(|s| s.to_string()))
+                    .join(" ")
+            )
+        })
+        .join(" ");
+
+    fn contains(haystack: &KakouneRange, needle: &KakouneRange) -> bool {
+        haystack.start <= needle.start && haystack.end >= needle.end
+    }
+
+    // Find an interesting range to select initially. We use the smallest one that goes beyond
+    // the main selection. We only consider the main selection here and hope that the index
+    // works well for other selections too.
+    let index_of_next_bigger_range = {
+        let mut cur = &selection_ranges[0];
+        let mut i = 0;
+        loop {
+            let range = lsp_range_to_kakoune(&cur.range, &document.text, ctx.offset_encoding);
+            // Found a range that exceeds the main selection's range.
+            if !contains(&selections[0], &range) {
+                break i;
+            }
+            match cur.parent.as_deref() {
+                Some(parent) => cur = parent,
+                None => break i,
+            }
+            i += 1;
+        }
+    };
+
+    let command = formatdoc!(
+        "evaluate-commands -client {} %[
+             set-option window lsp_selection_ranges {}
+             lsp-selection-range-show
+             lsp-selection-range-select {}
+         ]",
+        meta.client.as_ref().unwrap(),
+        &transposed_selection_ranges,
+        index_of_next_bigger_range + 1,
+    );
+    ctx.exec(meta, command);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -201,6 +201,14 @@ pub struct TextDocumentRenameParams {
     pub new_name: String,
 }
 
+#[derive(Clone, Deserialize, Debug)]
+pub struct SelectionRangePositionParams {
+    // The cursor position.
+    pub position: KakounePosition,
+    // The ranges of all Kakoune selections.
+    pub selections_desc: String,
+}
+
 // Language Server
 
 // XXX serde(untagged) ?
@@ -251,7 +259,7 @@ pub enum HoverType {
     },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KakouneRange {
     pub start: KakounePosition,
     pub end: KakounePosition,


### PR DESCRIPTION
This adds support for selecting interesting ranges around the cursors.
Usually the ranges correspond to AST nodes.  Add a lsp-selection-range
user mode no quickly navigate the ranges.

The VSCode UI is a bit different, it just needs Alt+Shift+{Left,Right},
whereas we need ":enter-user-mode lsp<ret>v" followed by j/k.

We also allow to navigate outside the user mode using
lsp-selection-range-select, but we don't yet have a way to
automatically request ranges whenever we need them (like VSCode).
We should try to do that, by simply requesting new ranges whenever the
cursor positions are outside the cone of the previously fetched ranges.

Backstory:
I started looking into this feature because I wanted to implement
Kakuone text objects for functions and type definitions (generalizing
lsp-next-symbol).  Usually, <a-a>{ and }} are good enough but there
are cases where they're not (like Python). It looks like this feature
won't help much because it doesn't allow to filter out uninteresting
ranges, but I guess it can be useful by itself.
For function/type defintion text objects we just need to go back to
our documentSymbol approach.

We might still extend this textDocument/selectionRange to text objects,
but it's probably not worth it, since it feels gimmicky.

Closes #288
