### PR TITLE
Use rust-analyzer over rls as default language server for Rust

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -256,24 +256,6 @@ args = ["stdio"]
 # See https://github.com/castwide/solargraph/blob/master/lib/solargraph/language_server/host.rb
 # "solargraph.completion" = true
 
-[language.rust]
-filetypes = ["rust"]
-roots = ["Cargo.toml"]
-command = "sh"
-args = [
-    "-c",
-    """
-        if path=$(rustup which rls 2>/dev/null); then
-            "$path"
-        else
-            rls
-        fi
-    """,
-]
-[language.rust.settings.rust]
-# See https://github.com/rust-lang/rls#configuration
-# features = []
-
 # [language.rust]
 # filetypes = ["rust"]
 # roots = ["Cargo.toml"]
@@ -281,25 +263,43 @@ args = [
 # args = [
 #     "-c",
 #     """
-#         if path=$(rustup which rust-analyzer 2>/dev/null); then
+#         if path=$(rustup which rls 2>/dev/null); then
 #             "$path"
 #         else
-#             rust-analyzer
+#             rls
 #         fi
 #     """,
 # ]
-# settings_section = "rust-analyzer"
-# [language.rust.settings.rust-analyzer]
-# hoverActions.enable = false # kak-lsp doesn't support this at the moment
-# # cargo.features = []
-# # See https://rust-analyzer.github.io/manual.html#configuration
-# # If you get 'unresolved proc macro' warnings, you have two options
-# # 1. The safe choice is two disable the warning:
-# diagnostics.disabled = ["unresolved-proc-macro"]
-# # 2. Or you can opt-in for proc macro support
-# procMacro.enable = true
-# cargo.loadOutDirsFromCheck = true
-# # See https://github.com/rust-analyzer/rust-analyzer/issues/6448
+# [language.rust.settings.rust]
+# # See https://github.com/rust-lang/rls#configuration
+# # features = []
+
+[language.rust]
+filetypes = ["rust"]
+roots = ["Cargo.toml"]
+command = "sh"
+args = [
+    "-c",
+    """
+        if path=$(rustup which rust-analyzer 2>/dev/null); then
+            "$path"
+        else
+            rust-analyzer
+        fi
+    """,
+]
+settings_section = "rust-analyzer"
+[language.rust.settings.rust-analyzer]
+hoverActions.enable = false # kak-lsp doesn't support this at the moment
+# cargo.features = []
+# See https://rust-analyzer.github.io/manual.html#configuration
+# If you get 'unresolved proc macro' warnings, you have two options
+# 1. The safe choice is two disable the warning:
+diagnostics.disabled = ["unresolved-proc-macro"]
+# 2. Or you can opt-in for proc macro support
+procMacro.enable = true
+cargo.loadOutDirsFromCheck = true
+# See https://github.com/rust-analyzer/rust-analyzer/issues/6448
 
 [language.terraform]
 filetypes = ["terraform"]


### PR DESCRIPTION
rust-analyzer has much more features than rls and it keeps getting
better. It has been pretty stable recently.  Let's encourage users
to make the switch. Keep around a commented rls config, just in case.
