### PR TITLE
Write semantic tokens config with one rule per line using inline tables

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -353,11 +353,11 @@ The faces used for semantic tokens and modifiers can be modified in `kak-lsp.tom
 ----
 [semantic_tokens]
 faces = [
-    {token="variable", face="const_variable_declaration", modifiers=["constant", "declaration"]},
+    {face="const_variable_declaration", token="variable", modifiers=["constant", "declaration"]},
 ]
 ----
 
-where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `token` and `face` are required.
+where `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config), `token` is the token's name as reported by the language server (see `lsp-capabilities`) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `token` and `face` are required.
 
 You may create any arbitrary number of definitions with permutations between the token names and modifiers reported by the server. For an entry to match a token, all the entry's modifiers must exist on the token. However, the token may have additional modifiers not assigned in the config entry. +
 `kak-lsp` will find the most specific matching configuration to apply, where specificity is defined as the number of matching modifiers. If multiple matching entries have the same number of modifiers, the one that was defined last in the configuration wins.
@@ -370,9 +370,9 @@ Assuming the following configuration,
 ----
 [semantic_tokens]
 faces = [
-    {token="variable", face="const_variable_declaration", modifiers=["constant","declaration"]},
-    {token="variable", face="const_variable", modifiers=["constant"]},
-    {token="variable", face="variable"},
+    {face="const_variable_declaration", token="variable", modifiers=["constant","declaration"]},
+    {face="const_variable", token="variable", modifiers=["constant"]},
+    {face="variable", token="variable"},
 ]
 ----
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -347,15 +347,14 @@ hook global WinSetOption filetype=<language> %{
 }
 ----
 
-The faces used for semantic tokens and modifiers can be modified in `kak-lsp.toml`, under the `semantic_tokens` section.
-The syntax for such an entry is
+The faces used for semantic tokens and modifiers can be modified in `kak-lsp.toml`, using the `semantic_tokens.faces` array, for example:
 
 [source,toml]
 ----
-[[semantic_tokens]]
-token = "variable"
-face = "const_variable_declaration"
-modifiers = ["constant", "declaration"]
+[semantic_tokens]
+faces = [
+    {token="variable", face="const_variable_declaration", modifiers=["constant", "declaration"]},
+]
 ----
 
 where `token` is the token's name as reported by the language server (see `lsp-capabilities`), `face` is the face that will be applied in Kakoune (you'll want to define these in your theme/config) and `modifiers` is an array of modifier names (also reported by the language server). `modifiers` may be omitted, but `token` and `face` are required.
@@ -369,19 +368,12 @@ Assuming the following configuration,
 
 [source,toml]
 ----
-[[semantic_tokens]]
-token = "variable"
-face = "const_variable_declaration"
-modifiers = ["constant", "declaration"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "const_variable"
-modifiers = ["constant"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "variable"
+[semantic_tokens]
+faces = [
+    {token="variable", face="const_variable_declaration", modifiers=["constant","declaration"]},
+    {token="variable", face="const_variable", modifiers=["constant"]},
+    {token="variable", face="variable"},
+]
 ----
 
 `kak-lsp` will perform these mappings:

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -369,15 +369,15 @@ command = "zls"
 # - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
 [semantic_tokens]
 faces = [
-    {token="comment", face="documentation", modifiers=["documentation"]},
-    {token="comment", face="comment"},
-    {token="function", face="function"},
-    {token="keyword", face="keyword"},
-    {token="namespace", face="module"},
-    {token="operator", face="operator"},
-    {token="string", face="string"},
-    {token="type", face="type"},
-    {token="variable", face="default+d", modifiers=["readonly"]},
-    {token="variable", face="default+d", modifiers=["constant"]},
-    {token="variable", face="variable"},
+    {face="documentation", token="comment", modifiers=["documentation"]},
+    {face="comment", token="comment"},
+    {face="function", token="function"},
+    {face="keyword", token="keyword"},
+    {face="module", token="namespace"},
+    {face="operator", token="operator"},
+    {face="string", token="string"},
+    {face="type", token="type"},
+    {face="default+d", token="variable", modifiers=["readonly"]},
+    {face="default+d", token="variable", modifiers=["constant"]},
+    {face="variable", token="variable"},
 ]

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -367,49 +367,17 @@ command = "zls"
 # Examples:
 # - TypeScript: https://github.com/microsoft/vscode-languageserver-node/blob/2645fb54ea1e764aff71dee0ecc8aceff3aabf56/client/src/common/semanticTokens.ts#L58
 # - Rust Analyzer: https://github.com/rust-analyzer/rust-analyzer/blob/f6da603c7fe56c19a275dc7bab1f30fe1ad39707/crates/ide/src/syntax_highlighting.rs#L42
-[[semantic_tokens]]
-token = "comment"
-face = "documentation"
-modifiers = ["documentation"]
-
-[[semantic_tokens]]
-token = "comment"
-face = "comment"
-
-[[semantic_tokens]]
-token = "function"
-face = "function"
-
-[[semantic_tokens]]
-token = "keyword"
-face = "keyword"
-
-[[semantic_tokens]]
-token = "namespace"
-face = "module"
-
-[[semantic_tokens]]
-token = "operator"
-face = "operator"
-
-[[semantic_tokens]]
-token = "string"
-face = "string"
-
-[[semantic_tokens]]
-token = "type"
-face = "type"
-
-[[semantic_tokens]]
-token = "variable"
-face = "default+d"
-modifiers = ["readonly"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "default+d"
-modifiers = ["constant"]
-
-[[semantic_tokens]]
-token = "variable"
-face = "variable"
+[semantic_tokens]
+faces = [
+    {token="comment", face="documentation", modifiers=["documentation"]},
+    {token="comment", face="comment"},
+    {token="function", face="function"},
+    {token="keyword", face="keyword"},
+    {token="namespace", face="module"},
+    {token="operator", face="operator"},
+    {token="string", face="string"},
+    {token="type", face="type"},
+    {token="variable", face="default+d", modifiers=["readonly"]},
+    {token="variable", face="default+d", modifiers=["constant"]},
+    {token="variable", face="variable"},
+]

--- a/src/general.rs
+++ b/src/general.rs
@@ -252,6 +252,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                     token_types: ctx
                         .config
                         .semantic_tokens
+                        .faces
                         .iter()
                         .map(|token_config| token_config.token.clone().into())
                         // Collect into set first to remove duplicates
@@ -261,6 +262,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                     token_modifiers: ctx
                         .config
                         .semantic_tokens
+                        .faces
                         .iter()
                         // Get all modifiers used in token definitions
                         .flat_map(|token_config| token_config.modifiers.clone())

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -75,15 +75,20 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
                     .map(|bit| &legend.token_modifiers[bit as usize])
                     .collect();
 
-                let candidates = ctx.config.semantic_tokens.iter().filter(|token_config| {
-                    token_name == token_config.token &&
+                let candidates = ctx
+                    .config
+                    .semantic_tokens
+                    .faces
+                    .iter()
+                    .filter(|token_config| {
+                        token_name == token_config.token &&
                         // All the config's modifiers must exist on the token for this
                         // config to match.
                         token_config
                         .modifiers
                         .iter()
                         .all(|modifier| token_modifiers.contains(&modifier))
-                });
+                    });
 
                 // But not all the token's modifiers must exist on the config.
                 // Therefore, we use the config that matches the most modifiers.

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,8 +120,8 @@ impl<'de> Deserialize<'de> for SemanticTokenConfig {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct SemanticTokenFace {
-    pub token: String,
     pub face: String,
+    pub token: String,
     #[serde(default)]
     pub modifiers: Vec<SemanticTokenModifier>,
 }


### PR DESCRIPTION
In our config, each entry takes up 5 lines.  Since some language
servers (like rust-analyzer) provide a large number of tokens (>30),
this means that a semantic token configuration quickly exceeds the
size of a terminal window, which makes it a bit less convenient to
skim/read/edit.

We can already use [TOML Inline
Tables](https://github.com/toml-lang/toml/blob/master/toml.md#user-content-inline-table)
to use only one line for each token-face-rule.
However, that would mean we'd need to write something like

	semantic_tokens = [ ... ]

which we can only write at the beginning of kak-lsp.toml (because it
must be inside the nameless global TOML table).  I'd like to keep the
semantic tokens configuration at the bottom of this file because unlike
server configuration, this feature is not required for basic operation.

Use "semantic_tokens.rules" instead of "semantic_tokens" so we can
write it as inline table anywhere in the TOML file. The old syntax
continues to be valid.

Potential concerns:
- the "rules" name feels arbitrary, I couldn't come up with a better name.

Closes #558
