### PR TITLE
Introduce text objects for selecting functions and other symbols

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -167,6 +167,10 @@ hook global WinSetOption filetype=rust %{
 }
 ----
 
+* `lsp-object` command and its [object mode](https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#object-mode) mappings to select adjacent or surrounding symbols. The predefined object types are:
+** `e` to select functions and methods
+** `k` to select classes and structs
+** `a` or `<a-a>` to select any symbol
 * `lsp-next-symbol` and `lsp-previous-symbol` command to go to the buffer's next and current/previous symbol.
 * `lsp-hover-next-symbol` and `lsp-hover-previous-symbol` to show hover of the buffer's next and current/previous symbol.
 * `lsp-rename <new_name>` and `lsp-rename-prompt` commands to rename the symbol under the main cursor.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -292,6 +292,9 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
         "kak-lsp/next-or-previous-symbol" => {
             document_symbol::next_or_prev_symbol(meta, params, ctx);
         }
+        "kak-lsp/object" => {
+            document_symbol::object(meta, params, ctx);
+        }
         request::Formatting::METHOD => {
             formatting::text_document_formatting(meta, params, ctx);
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -229,6 +229,15 @@ pub struct NextOrPrevSymbolParams {
     pub hover: bool,
 }
 
+#[derive(Clone, Deserialize, Debug)]
+pub struct ObjectParams {
+    pub count: u32,
+    pub mode: String,
+    pub position: KakounePosition,
+    pub selections_desc: String,
+    pub symbol_kinds: Vec<String>,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct TextDocumentRenameParams {


### PR DESCRIPTION
lsp-{next,previous}-{function,symbol} - bound to "[]{}90()" in the
lsp user mode have proven useful to my workflow. Let's expand on
these ideas with an approach that is more native to Kakoune: text
objects.
Introduce lsp-text-object, which moves similar to ]p, ]( and friends,
except it matches LSP symbol ranges.

New object mode mappings were chosen to not collide with any of
another plugin, https://github.com/Delapouite/kakoune-text-objects

"\<a-a>" is a convenience alias for "a", since "\<a-a>a" is awkward
to type.

]a selects from the cursor to the end of a symbol, similar to ]p.
The alternative behavior is \<a-]>a, which selects only the symbol.
Maybe they should be switched, since we already have }a which is
close to first behavior?

The surrounding modes \<a-a> and \<a-i> only select nodes that surround
the cursor. This could be relaxed in future.

The implementation uses lsp-connect, so it's hacky (it doesn't convert
LSP coordinates properly) but we can fix that later.
