### PR TITLE
Add textDocument/inlayHint and experimental/inlayHints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Additions:
+- Support the new `textDocument/inlayHint` request from LSP v3.17, and the same protocol with the `experimental/inlayHints` request currently used by rust-analyzer.
+
 ## 12.1.0 - 2022-03-28
 
 Additions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.91.1"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
+checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
 dependencies = [
  "bitflags",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ glob = "0.3.0"
 indoc = "1.0.3"
 unindent = "0.1.7"
 itertools = "0.10.1"
-lsp-types = { version = "0.91.1", features = ["proposed"] }
+lsp-types = { version = "0.92.1", features = ["proposed"] }
 jsonrpc-core = "18.0.0"
 libc = "0.2.71"
 rand = "0.8.4"

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -321,20 +321,20 @@ set-option global lsp_config %{
 }
 ----
 
-== Inlay hints for rust-analyzer
+== Inlay hints
 
-Inlay hints are a feature supported by https://github.com/rust-analyzer/rust-analyzer[rust-analyzer], which show inferred types, parameter names in function calls, and the types of chained calls inline in the code. To enable support for it in kak-lsp, add the following to your `kakrc`:
+Inlay hints are a feature proposed for LSP 3.17 to show inferred types, parameter names in function calls, and the types of chained calls inline in the code. To enable support for it in kak-lsp, add the following to your `kakrc`:
 
 [source,kak]
 ----
-hook global WinSetOption filetype=rust %{
-  hook window -group rust-inlay-hints BufReload .* rust-analyzer-inlay-hints
-  hook window -group rust-inlay-hints NormalIdle .* rust-analyzer-inlay-hints
-  hook window -group rust-inlay-hints InsertIdle .* rust-analyzer-inlay-hints
-  hook -once -always window WinSetOption filetype=.* %{
-    remove-hooks window rust-inlay-hints
-  }
-}
+lsp-inlay-hints-enable global
+----
+
+Currently https://github.com/rust-analyzer/rust-analyzer[rust-analyzer] needs a different request
+
+[source,kak]
+----
+lsp-experimental-inlay-hints-enable global
 ----
 
 You can change the hints' face with `set-face global InlayHint <face>`.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -323,6 +323,14 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
             semantic_tokens::tokens_request(meta, ctx);
         }
 
+        request::InlayHintRequest::METHOD => {
+            inlay_hints::inlay_hints(meta, params, ctx);
+        }
+
+        inlay_hints::ExperimentalInlayHintRequest::METHOD => {
+            inlay_hints::experimental_inlay_hints(meta, params, ctx);
+        }
+
         // CCLS
         ccls::NavigateRequest::METHOD => {
             ccls::navigate(meta, params, ctx);
@@ -348,11 +356,6 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
         // eclipse.jdt.ls
         "eclipse.jdt.ls/organizeImports" => {
             eclipse_jdt_ls::organize_imports(meta, ctx);
-        }
-
-        // rust-analyzer
-        rust_analyzer::InlayHints::METHOD => {
-            rust_analyzer::inlay_hints(meta, params, ctx);
         }
 
         // texlab

--- a/src/general.rs
+++ b/src/general.rs
@@ -81,6 +81,9 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 semantic_tokens: None,
                 code_lens: None,
                 file_operations: None,
+                inlay_hint: Some(InlayHintWorkspaceClientCapabilities {
+                    refresh_support: Some(false),
+                }),
             }),
             text_document: Some(TextDocumentClientCapabilities {
                 synchronization: Some(TextDocumentSyncClientCapabilities {
@@ -279,6 +282,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                     dynamic_registration: Some(false),
                 }),
                 moniker: None,
+                inlay_hint: Some(Default::default()),
             }),
             window: Some(WindowClientCapabilities {
                 work_done_progress: Some(true),
@@ -444,6 +448,16 @@ pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
                 .map(SemanticTokenModifier::as_str)
                 .join(", ")
         ));
+    }
+
+    if let Some(ref provider) = server_capabilities.inlay_hint_provider {
+        let supported = match *provider {
+            OneOf::Left(bool) => bool,
+            OneOf::Right(_) => true,
+        };
+        if supported {
+            features.push("lsp-inlay-hints".to_string());
+        }
     }
 
     let command = formatdoc!(

--- a/src/language_features/inlay_hints.rs
+++ b/src/language_features/inlay_hints.rs
@@ -1,0 +1,105 @@
+use itertools::Itertools;
+use lsp_types::{
+    request::{InlayHintRequest, Request},
+    InlayHint, InlayHintLabel, InlayHintParams, Position, Range, TextDocumentIdentifier, Url,
+};
+use serde::Deserialize;
+
+use crate::{
+    context::Context,
+    position::lsp_position_to_kakoune,
+    types::{EditorMeta, EditorParams},
+    util::{editor_quote, escape_tuple_element},
+};
+
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
+struct InlayHintsOptions {
+    buf_line_count: u32,
+}
+
+pub enum ExperimentalInlayHintRequest {}
+
+// For now, rust analyzer implements this as experimental/inlayHint
+impl Request for ExperimentalInlayHintRequest {
+    type Params = InlayHintParams;
+    type Result = Option<Vec<InlayHint>>;
+    const METHOD: &'static str = "experimental/inlayHints";
+}
+
+pub fn experimental_inlay_hints(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params = InlayHintsOptions::deserialize(params).unwrap();
+    let req_params = InlayHintParams {
+        work_done_progress_params: Default::default(),
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
+    };
+    ctx.call::<ExperimentalInlayHintRequest, _>(meta, req_params, move |ctx, meta, response| {
+        inlay_hints_response(meta, response.unwrap_or_default(), ctx)
+    });
+}
+
+pub fn inlay_hints(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params = InlayHintsOptions::deserialize(params).unwrap();
+    let req_params = InlayHintParams {
+        work_done_progress_params: Default::default(),
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
+    };
+    ctx.call::<InlayHintRequest, _>(meta, req_params, move |ctx, meta, response| {
+        inlay_hints_response(meta, response.unwrap_or_default(), ctx)
+    });
+}
+
+pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: &mut Context) {
+    let document = match ctx.documents.get(&meta.buffile) {
+        Some(document) => document,
+        None => return,
+    };
+    let ranges = inlay_hints
+        .into_iter()
+        .map(
+            |InlayHint {
+                 position,
+                 label,
+                 padding_left,
+                 padding_right,
+                 ..
+             }| {
+                let position =
+                    lsp_position_to_kakoune(&position, &document.text, ctx.offset_encoding);
+                let label = match label {
+                    InlayHintLabel::String(s) => s,
+                    InlayHintLabel::LabelParts(parts) => {
+                        parts.iter().map(|x| x.value.as_str()).collect()
+                    }
+                };
+                let padding_left = if padding_left.unwrap_or(false) {
+                    " "
+                } else {
+                    ""
+                };
+                let padding_right = if padding_right.unwrap_or(false) {
+                    "{Default} "
+                } else {
+                    ""
+                };
+                // Escape markup inside label
+                let label = escape_tuple_element(&label).replace('{', "\\{");
+                editor_quote(&format!(
+                    "{position}+0|{padding_left}{{InlayHint}}{label}{padding_right}",
+                ))
+            },
+        )
+        .join(" ");
+    let command = format!("set buffer lsp_inlay_hints {} {}", meta.version, ranges);
+    let command = format!(
+        "eval -buffer {} -verbatim -- {}",
+        editor_quote(&meta.buffile),
+        command
+    );
+    ctx.exec(meta, command)
+}

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -10,6 +10,7 @@ pub mod formatting;
 pub mod goto;
 pub mod highlights;
 pub mod hover;
+pub mod inlay_hints;
 pub mod range_formatting;
 pub mod rename;
 pub mod rust_analyzer;


### PR DESCRIPTION
Close #600 

For now this doesnt remove the old rust-analyzer api, and adds both the `textDocument/inlayHint` and `experimental/inlayHints`. The former is proposed for LSP v3.17, and the latter is the temporary name used for the proposed api by rust-analyzer.

I think we should remove both old apis when the new one is standardized, and adapted by rust-analyzer, since i have seen no indication that other servers have used the rust-analyzer or experimental prefix versions.