### PR TITLE
Disable inlay diagnostics in insert mode

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1842,10 +1842,13 @@ define-command lsp-diagnostic-lines-disable -params 1 -docstring "lsp-diagnostic
 
 define-command lsp-inlay-diagnostics-enable -params 1 -docstring "lsp-inlay-diagnostics-enable <scope>: Enable inlay diagnostics highlighting for <scope>" %{
     add-highlighter "%arg{1}/lsp_diagnostics" replace-ranges lsp_diagnostics
+	hook %arg{1} -group lsp-inlay-diagnostics ModeChange (push|pop):.*:insert "remove-highlighter %arg{1}/lsp_diagnostics"
+	hook %arg{1} -group lsp-inlay-diagnostics ModeChange (push|pop):insert:.* "add-highlighter %arg{1}/lsp_diagnostics replace-ranges lsp_diagnostics"
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command lsp-inlay-diagnostics-disable -params 1 -docstring "lsp-inlay-diagnostics-disable <scope>: Disable inlay diagnostics highlighting for <scope>"  %{
     remove-highlighter "%arg{1}/lsp_diagnostics"
+    remove-hooks %arg{1} lsp-inlay-diagnostics
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command lsp-auto-hover-enable -params 0..1 -client-completion \


### PR DESCRIPTION
This seems like the better default.

See the discussion in https://discuss.kakoune.com/t/sane-kak-lsp-config-hook/2019
