### PR TITLE
Add envs parameter to language config

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -40,7 +40,7 @@ pub fn start(
         // should be fine to unwrap because request was already routed which means language is configured
         let lang = &config.language[&route.language];
         offset_encoding = lang.offset_encoding;
-        lang_srv = match language_server_transport::start(&lang.command, &lang.args) {
+        lang_srv = match language_server_transport::start(&lang.command, &lang.args, &lang.envs) {
             Ok(ls) => ls,
             Err(err) => {
                 // If we think that the server command is not from the default config, then we

--- a/src/language_server_transport.rs
+++ b/src/language_server_transport.rs
@@ -16,10 +16,15 @@ pub struct LanguageServerTransport {
     pub errors: Worker<Void, Void>,
 }
 
-pub fn start(cmd: &str, args: &[String]) -> Result<LanguageServerTransport, String> {
+pub fn start(
+    cmd: &str,
+    args: &[String],
+    envs: &HashMap<String, String>,
+) -> Result<LanguageServerTransport, String> {
     info!("Starting Language server `{} {}`", cmd, args.join(" "));
     let mut child = match Command::new(cmd)
         .args(args)
+        .envs(envs)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,6 +47,8 @@ pub struct LanguageConfig {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
+    #[serde(default)]
+    pub envs: HashMap<String, String>,
     pub settings_section: Option<String>,
     pub settings: Option<Value>,
     pub offset_encoding: Option<OffsetEncoding>,


### PR DESCRIPTION
Justification and use case in #606; closes #606.

I chose the name `envs` since it's what Rust uses and seems reasonable, but can rename depending on what's desired.