### PR TITLE
remove rust-analyzer inlay-hints implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 
+Deprecations:
+- `rust-analyzer-inlay-hints` is deprecated in favor of `lsp-experimental-inlay-hints-enable`. Inlay hints now requires `rust-analyzer` version >= 2022-04-18. (#602, #613).
+
 Additions:
-- Support the new `textDocument/inlayHint` request from LSP v3.17, and the same protocol with the `experimental/inlayHints` request currently used by rust-analyzer.
+- Support the new `textDocument/inlayHint` request from LSP v3.17.
 
 ## 12.1.0 - 2022-03-28
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -331,13 +331,6 @@ Inlay hints are a feature proposed for LSP 3.17 to show inferred types, paramete
 lsp-inlay-hints-enable global
 ----
 
-Currently https://github.com/rust-analyzer/rust-analyzer[rust-analyzer] needs a different request
-
-[source,kak]
-----
-lsp-experimental-inlay-hints-enable global
-----
-
 You can change the hints' face with `set-face global InlayHint <face>`.
 
 == Semantic Tokens

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1176,22 +1176,6 @@ buf_line_count = ${kak_buf_line_count}
 " | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
-define-command -hidden lsp-experimental-inlay-hints -docstring "lsp-experimental-inlay-hints: Request inlay hints with experimental prefix" %{
-  lsp-did-change-and-then lsp-experimental-inlay-hints-request
-}
-
-define-command -hidden lsp-experimental-inlay-hints-request %{
-    nop %sh{ (printf %s "
-session  = \"${kak_session}\"
-buffile  = \"${kak_buffile}\"
-filetype = \"${kak_opt_filetype}\"
-version  = ${kak_timestamp:-0}
-method   = \"experimental/inlayHints\"
-[params]
-buf_line_count = ${kak_buf_line_count}
-" | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
-}
-
 # CCLS Extension
 
 define-command ccls-navigate -docstring "Navigate C/C++/ObjectiveC file" -params 1 %{
@@ -1349,11 +1333,8 @@ method   = \"eclipse.jdt.ls/organizeImports\"
 
 # rust-analyzer extensions
 
-define-command -hidden rust-analyzer-inlay-hints -docstring "rust-analyzer-inlay-hints: request inlay hints (rust-analyzer).
-
-Deprecated: Delegates to lsp-experimental-inlay-hints. Once rust-analyzer switches to the official 
-textDocument/inlayHints request, this will be removed." %{
-    lsp-experimental-inlay-hints
+define-command -hidden rust-analyzer-inlay-hints -docstring "DEPRECATED, use lsp-inlay-hints-enable. request inlay hints" %{
+    lsp-inlay-hints
 }
 
 # texlab extensions
@@ -1911,18 +1892,6 @@ define-command lsp-inlay-hints-enable -params 1 -docstring "lsp-inlay-hints-enab
 define-command lsp-inlay-hints-disable -params 1 -docstring "lsp-inlay-hints-disable <scope>: disable inlay hints for <scope>"  %{
     remove-highlighter "%arg{1}/lsp_inlay_hints"
     remove-hooks %arg{1} lsp-inlay-hints
-} -shell-script-candidates %{ printf '%s\n' buffer global window }
-
-define-command lsp-experimental-inlay-hints-enable -params 1 -docstring "lsp-experimental-inlay-hints-enable <scope>: enable inlay hints with experimental request for <scope>" %{
-    add-highlighter "%arg{1}/lsp_inlay_hints" replace-ranges lsp_inlay_hints
-    hook -group lsp-experimental-inlay-hints %arg{1} BufReload .* lsp-experimental-inlay-hints
-    hook -group lsp-experimental-inlay-hints %arg{1} NormalIdle .* lsp-experimental-inlay-hints
-    hook -group lsp-experimental-inlay-hints %arg{1} InsertIdle .* lsp-experimental-inlay-hints
-} -shell-script-candidates %{ printf '%s\n' buffer global window }
-
-define-command lsp-experimental-inlay-hints-disable -params 1 -docstring "lsp-experimental-inlay-hints-disable <scope>: disable inlay hints with experimental request for <scope>"  %{
-    remove-highlighter "%arg{1}/lsp_inlay_hints"
-    remove-hooks %arg{1} lsp-experimental-inlay-hints
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 ### User mode ###

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -327,10 +327,6 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
             inlay_hints::inlay_hints(meta, params, ctx);
         }
 
-        inlay_hints::ExperimentalInlayHintRequest::METHOD => {
-            inlay_hints::experimental_inlay_hints(meta, params, ctx);
-        }
-
         // CCLS
         ccls::NavigateRequest::METHOD => {
             ccls::navigate(meta, params, ctx);

--- a/src/language_features/inlay_hints.rs
+++ b/src/language_features/inlay_hints.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use lsp_types::{
-    request::{InlayHintRequest, Request},
-    InlayHint, InlayHintLabel, InlayHintParams, Position, Range, TextDocumentIdentifier, Url,
+    request::InlayHintRequest, InlayHint, InlayHintLabel, InlayHintParams, Position, Range,
+    TextDocumentIdentifier, Url,
 };
 use serde::Deserialize;
 
@@ -15,29 +15,6 @@ use crate::{
 #[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
 struct InlayHintsOptions {
     buf_line_count: u32,
-}
-
-pub enum ExperimentalInlayHintRequest {}
-
-// For now, rust analyzer implements this as experimental/inlayHint
-impl Request for ExperimentalInlayHintRequest {
-    type Params = InlayHintParams;
-    type Result = Option<Vec<InlayHint>>;
-    const METHOD: &'static str = "experimental/inlayHints";
-}
-
-pub fn experimental_inlay_hints(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let params = InlayHintsOptions::deserialize(params).unwrap();
-    let req_params = InlayHintParams {
-        work_done_progress_params: Default::default(),
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
-        },
-        range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
-    };
-    ctx.call::<ExperimentalInlayHintRequest, _>(meta, req_params, move |ctx, meta, response| {
-        inlay_hints_response(meta, response.unwrap_or_default(), ctx)
-    });
 }
 
 pub fn inlay_hints(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {


### PR DESCRIPTION
rust-analyzer recently switched to the standard implementation.

https://github.com/rust-lang/rust-analyzer/pull/11935

See #600 for more info