### PR TITLE
Fix snippets

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -519,22 +519,31 @@ kak-lsp has experimental support for snippets. It is enabled by setting `snippet
 
 It uses the two faces `SnippetsNextPlaceholders` and `SnippetsOtherPlaceholders`, you may want to customize those.
 
-To properly use snippets, you'll probably want something like this:
+You'll probably want to add a mapping for `lsp-snippets-select-next-placeholders`, which allows
+to jump between tabstops (like function call arguments).
+
+For example, you can use `<tab>` to select a placeholder if there is one, or else execute
+`<tab>` as normal:
 
 [source,kak]
 ----
-def -hidden insert-c-n %{
- try %{
-   lsp-snippets-select-next-placeholders
-   exec '<a-;>d'
- } catch %{
-   exec -with-hooks '<c-n>'
- }
-}
-map global insert <c-n> "<a-;>: insert-c-n<ret>"
+map global normal <tab> ': try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>tab> }<ret>' -docstring 'Select next snippet placeholder'
+map global insert <tab> '<a-;>: try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>tab> }<ret>' -docstring 'Select next snippet placeholder'
 ----
 
-This maps `<c-n>` to select the next placeholder if there is one, and otherwise executes `<c-n>` as normal
+or `<c-n>` (while the completion menu is hidden):
+
+[source,kak]
+----
+map global normal <c-n> ': try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>c-n> }<ret>' -docstring 'Select next snippet placeholder'
+map global insert <c-n> '<a-;>: lsp-snippets-select-next-placeholders<ret>' -docstring 'Select next snippet placeholder'
+hook global InsertCompletionShow .* %{
+  unmap global insert <c-n> '<a-;>: lsp-snippets-select-next-placeholders<ret>'
+}
+hook global InsertCompletionHide .* %{
+  map global insert <c-n> '<a-;>: lsp-snippets-select-next-placeholders<ret>' -docstring 'Select next snippet placeholder'
+}
+----
 
 
 == Limitations


### PR DESCRIPTION
Its been a long time since ive used snippets, and they have been broken for me for a while, so i spent some time fixing it while listening to the new kendrick album :)

![Demo Gif](https://i.imgur.com/uw2HL9O.gif)

 - Snippets are now only fully expanded when the completions menu is closed, making them much more robust
 - The text that is inserted until the menu is closed is the snippets contents merged onto one line and with tabstops (cursor jump points) replaced with their placeholder text.

These two things result in a pretty smooth snippets experience, that is a lot more practical than the old implementation, while staying fairly simple.

Currently, i have only tested with rust-analyzer, but it should be better than the old implementation everywhere.

At some point i would like to rewrite the placeholder selection and location jumping, preferably not using perl, but that wont be this time.

Also, this includes a bit of infrastructure to perform actions when completions are closed, including properly deleting the temporary text. This could be used to implement #40 pretty easily, but text edits would then only be applied when the completions box is closed, and a temporary label would have to be used as insert_text. This is also probably not something ill do this time around