### PR TITLE
Add configuration for Elvish.

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -75,6 +75,12 @@ elmPath = "elm"
 elmFormatPath = "elm-format"
 elmTestPath = "elm-test"
 
+[language.elvish]
+filetypes = ["elvish"]
+roots = [".git", ".hg"]
+command = "elvish"
+args = ["-lsp"]
+
 [language.erlang]
 filetypes = ["erlang"]
 # See https://github.com/erlang-ls/erlang_ls.git for more information and


### PR DESCRIPTION
Filetype plugin for Elvish is part of Kakoune's repo
(https://github.com/mawww/kakoune/blob/master/rc/filetype/elvish.kak), so it
would make sense for kak-lsp to have a default config for Elvish too.