### PR TITLE
Fix blocking request hanging if unconfigured

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -80,6 +80,14 @@ pub fn start(config: &Config, initial_request: Option<String>) -> i32 {
                         "Language server is not configured for filetype `{}`",
                         &request.meta.filetype
                     );
+                    // If the editor is expecting a fifo response, give it one, so it won't hang.
+                    if let Some(ref fifo) = request.meta.fifo {
+                        let command = format!(
+                            "lsp-show-error 'Language server is not configured for filetype `{}`'",
+                            request.meta.filetype
+                        );
+                        std::fs::write(fifo, &*command).expect("Failed to write command to fifo");
+                    }
                     continue 'event_loop;
                 }
                 let language_id = language_id.unwrap();


### PR DESCRIPTION
To reproduce, run `lsp-formatting-sync` on a file without a configured lsp server.

I think this works for all the blocking commands I see in `lsp.kak`. I'm not sure what's appropriate for `write_response_to_fifo = true` calls, but I figure this is better than deadlock.

I'd like to add more visibility to other error conditions, but if a `lsp-show-error` triggers on _every_ request that fails due to a missing lsp configuration, it could bother auto hover users. Maybe that could be solved with a smarter auto hover implementation?