### PR TITLE
Show more errors in the editor

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -250,23 +250,9 @@ impl Context {
         id
     }
 
-    pub fn meta_for_session(&self, client: Option<String>) -> EditorMeta {
-        EditorMeta {
-            session: self.session.clone(),
-            client,
-            buffile: "".to_string(),
-            filetype: "".to_string(), // filetype is not used by ctx.exec, but it's definitely a code smell
-            version: 0,
-            fifo: None,
-            command_fifo: None,
-            write_response_to_fifo: false,
-            hook: false,
-        }
-    }
-
     pub fn meta_for_buffer(&self, client: Option<String>, buffile: &str) -> Option<EditorMeta> {
         let document = self.documents.get(buffile)?;
-        let mut meta = self.meta_for_session(client);
+        let mut meta = meta_for_session(self.session.clone(), client);
         meta.buffile = buffile.to_string();
         meta.version = document.version;
         Some(meta)
@@ -278,9 +264,23 @@ impl Context {
         buffile: &str,
         version: i32,
     ) -> EditorMeta {
-        let mut meta = self.meta_for_session(client);
+        let mut meta = meta_for_session(self.session.clone(), client);
         meta.buffile = buffile.to_string();
         meta.version = version;
         meta
+    }
+}
+
+pub fn meta_for_session(session: String, client: Option<String>) -> EditorMeta {
+    EditorMeta {
+        session,
+        client,
+        buffile: "".to_string(),
+        filetype: "".to_string(), // filetype is not used by ctx.exec, but it's definitely a code smell
+        version: 0,
+        fifo: None,
+        command_fifo: None,
+        write_response_to_fifo: false,
+        hook: false,
     }
 }

--- a/src/editor_transport.rs
+++ b/src/editor_transport.rs
@@ -127,8 +127,13 @@ pub fn start_unix(path: &path::Path, sender: Sender<EditorRequest>) {
                             continue;
                         }
                         debug!("From editor: {}", request);
-                        let request: EditorRequest =
-                            toml::from_str(&request).expect("Failed to parse editor request");
+                        let request: EditorRequest = match toml::from_str(&request) {
+                            Ok(req) => req,
+                            Err(err) => {
+                                error!("Failed to parse editor request: {}", err);
+                                continue;
+                            }
+                        };
                         if sender.send(request).is_err() {
                             return;
                         };

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -271,7 +271,7 @@ pub fn apply_edit_from_server(
     ctx: &mut Context,
 ) -> Result<Value, jsonrpc_core::Error> {
     let params: ApplyWorkspaceEditParams = params.parse()?;
-    let meta = ctx.meta_for_session(None);
+    let meta = meta_for_session(ctx.session.clone(), None);
     let response = apply_edit(meta, params.edit, ctx);
     Ok(serde_json::to_value(response).unwrap())
 }


### PR DESCRIPTION
Hey! I rolled with [the idea of reporting errors for only calls that happen outside of hook context](https://github.com/kak-lsp/kak-lsp/pull/630#issuecomment-1191106482), and I think it works pretty well so far. I haven't gotten to unsupported requests yet, but I added the error cases I ran into from bad config and flaky lsp servers. I also removed some panics after I brought down `kak-lsp` a few times.

The hook detection relies on a bit of a hack. From what I can tell, [`%val{hook_param}` is always set when running in a hook, though it's empty for hooks that don't have a hook_param](https://github.com/mawww/kakoune/blob/e83dbdcd2cbddb30ac63ec503c76b46b80ffe44d/src/hook_manager.cc#L114). I was thinking of asking for a more official way to detect if we're running in a hook or not in kakoune after this.

Some ideas from while I was working on this:
- It's awkward if someone installs a new kak-lsp that gets started in a kakoune session that's still running outdated kak-side code; after this PR that would make it print errors for all commands, even in a hook. I'm guessing this isn't supported, but it could be useful in general to warn the user if they update kak-lsp swithout restarting kakoune?
- It's easy to write sh code that can mess up request toml formatting in  `lsp.kak`. e.g. try `:e foo."'"` and see the requests fail to parse. Has anyone considered moving some or all of the env parsing logic into `kak-lsp --request` itself? (This might require a more complicated cli, with different cli commands for different operations... But shell escapes are also tricky.)