### PR TITLE
Disable completion snippet placeholders when leaving insert mode

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -526,7 +526,6 @@ For example, you can use `<tab>` to select a placeholder if there is one, or els
 
 [source,kak]
 ----
-map global normal <tab> ': try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>tab> }<ret>' -docstring 'Select next snippet placeholder'
 map global insert <tab> '<a-;>: try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>tab> }<ret>' -docstring 'Select next snippet placeholder'
 ----
 
@@ -534,7 +533,6 @@ or `<c-n>` (might need to hide the completion menu with Kakoune's `<c-o>` comman
 
 [source,kak]
 ----
-map global normal <c-n> ': try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>c-n> }<ret>' -docstring 'Select next snippet placeholder'
 map global insert <c-n> '<a-;>: lsp-snippets-select-next-placeholders<ret>' -docstring 'Select next snippet placeholder'
 hook global InsertCompletionShow .* %{
   unmap global insert <c-n> '<a-;>: lsp-snippets-select-next-placeholders<ret>'

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -2103,6 +2103,10 @@ define-command lsp-enable -docstring "Default integration with kak-lsp" %{
     hook -group lsp global BufSetOption lsp_config=.* lsp-did-change-config
     hook -group lsp global BufSetOption lsp_server_configuration=.* lsp-did-change-config
     hook -group lsp global InsertIdle .* lsp-completion
+    hook -group lsp global ModeChange pop:insert:.* %{
+        set-option window lsp_snippets_placeholders
+        set-option window lsp_snippets_placeholder_groups
+    }
     # A non-empty hook parameter means some completion was inserted.
     hook -group lsp global InsertCompletionHide .+ lsp-completion-accepted
     hook -group lsp global NormalIdle .* %{
@@ -2158,6 +2162,10 @@ define-command lsp-enable-window -docstring "Default integration with kak-lsp in
     hook -group lsp window WinSetOption lsp_config=.* lsp-did-change-config
     hook -group lsp window WinSetOption lsp_server_configuration=.* lsp-did-change-config
     hook -group lsp window InsertIdle .* lsp-completion
+    hook -group lsp window ModeChange pop:insert:.* %{
+        set-option window lsp_snippets_placeholders
+        set-option window lsp_snippets_placeholder_groups
+    }
     # A non-empty hook parameter means some completion was inserted.
     hook -group lsp window InsertCompletionHide .+ lsp-completion-accepted
     hook -group lsp window NormalIdle .* %{


### PR DESCRIPTION
When snippets are enabled, we can type

	openat<c-n>somefd<tab>somefile<tab>O_CREAT,<space>0644

to get

	openat(somefd, somefile, O_CREAT, 0644)

Very fancy.
Sadly, I often can't fill in all arguments without looking
around or fixing some other code.  If I stop somewhere in
the middle, highlighting remains, and can only be cleared
with `lsp-snippets-select-next-placeholders`.  For example
`openat<c-n><esc>` gives

	openat(%(), const char *file, int oflag, ...)

where the tail of arguments is still highlighted.  This is supremely
annoying because I usually don't want to simply resume where I left
of.

Also, the last snippet-placeholder is usually after the closing
parenthesis. Jumping there makes sense when staying in insert mode
throughout but not when when exiting insertion mode halfway through
the arguments.

Let's just hide the placeholder highlighting as soon we exit insert
mode. This should make snippets interfere less with normal editing.

It seems fine to leave the raw placeholder text because it serves
as documentation and other editors like VSCode do the same.

If anyone really cares about this, we can use a separate hook group,
that can be disabled specifically.
