### PR TITLE
Add section with suggested mappings instead of mapping keys ourselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Here are some notable changes. See the git log for a full list of changes.
 
 Breaking changes:
 - Completion snippet support is now enabled again in the default config.
+- The default object mode mappings have been removed. Users are expected to add their preferred mappings. The README now has a section with recommended mappings.
 
 ## 12.2.1 - 2022-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+Here are some notable changes. See the git log for a full list of changes.
+
+Breaking changes:
+- Completion snippet support is now enabled again in the default config.
+
 ## 12.2.1 - 2022-05-08
 
 Fixes:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -7,6 +7,7 @@ kak-lsp is a https://microsoft.github.io/language-server-protocol/[Language Serv
 1. <<Install kak-lsp>>
 2. <<Install language servers for your desired languages>>
 3. <<Configure Kakoune to enable kak-lsp>>
+4. <<Configure mappings>>
 
 === Install kak-lsp
 
@@ -126,6 +127,24 @@ hook global WinSetOption filetype=(rust|python|go|javascript|typescript|c|cpp) %
 }
 ----
 
+=== Configure mappings
+
+There are three default mappings in goto-mode: `gd` (`lsp-definition`), `gy`
+(`lsp-type-definition`) and `gr` (`lsp-references`).  You can override them in your kakrc after
+this plugin is loaded.
+
+Here are additional recommended mappings. See below for the meaning of each command.
+
+[source,kak]
+----
+map global user l %{:enter-user-mode lsp<ret>} -docstring "LSP mode"
+map global insert <tab> '<a-;>:try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>tab> }<ret>' -docstring 'Select next snippet placeholder'
+map global object a '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
+map global object <a-a> '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
+map global object e '<a-semicolon>lsp-object Function Method<ret>' -docstring 'LSP function or method'
+map global object k '<a-semicolon>lsp-object Class Interface Struct<ret>' -docstring 'LSP class interface or struct'
+----
+
 == Usage
 
 NOTE: Contents below corresponds to the master branch HEAD and could be slightly out-of-sync
@@ -176,10 +195,7 @@ hook global WinSetOption filetype=rust %{
 }
 ----
 
-* `lsp-object` command and its [object mode](https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#object-mode) mappings to select adjacent or surrounding symbols. The predefined object types are:
-** `e` to select functions and methods
-** `k` to select classes and structs
-** `a` or `<a-a>` to select any symbol
+* `lsp-object` command to select adjacent or surrounding syntax tree nodes in [object mode](https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#object-mode)
 * `lsp-next-symbol` and `lsp-previous-symbol` command to go to the buffer's next and current/previous symbol.
 * `lsp-hover-next-symbol` and `lsp-hover-previous-symbol` to show hover of the buffer's next and current/previous symbol.
 * `lsp-rename <new_name>` and `lsp-rename-prompt` commands to rename the symbol under the main cursor.
@@ -203,14 +219,7 @@ even if the Kakoune session is still up and running. Change `server.timeout` in 
 to tweak this duration, or set it to 0 to disable this behavior. In any scenario,  a new request
 would spin up a fresh server if it is down.
 
-* `lsp` https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#user-modes[user mode].
-  The following example mapping gives you access to the shortcuts from below table after typing `,l`.
-
-[source,kak]
-----
-map global user l %{: enter-user-mode lsp<ret>} -docstring "LSP mode"
-----
-
+* `lsp` https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#user-modes[user mode] with the following default mappings:
 
 |===
 | Binding | Command
@@ -514,22 +523,14 @@ Current limitations of this feature are:
 
 == Snippets
 
-kak-lsp has experimental support for snippets. It is enabled by setting `snippet_support = true` at the top level of the config.
+Snippets are completions that come with placeholders ("tabstops") in the places you likely want
+to insert text (for example function call arguments).  The placeholders are highlighted with
+the two faces `SnippetsNextPlaceholders` and `SnippetsOtherPlaceholders`.
 
-It uses the two faces `SnippetsNextPlaceholders` and `SnippetsOtherPlaceholders`, you may want to customize those.
-
-You'll probably want to add a mapping for `lsp-snippets-select-next-placeholders`, which allows
-to jump between tabstops (like function call arguments).
-
-For example, you can use `<tab>` to select a placeholder if there is one, or else execute
-`<tab>` as normal:
-
-[source,kak]
-----
-map global insert <tab> '<a-;>:try lsp-snippets-select-next-placeholders catch %{ execute-keys -with-hooks <lt>tab> }<ret>' -docstring 'Select next snippet placeholder'
-----
-
-or `<c-n>` (might need to hide the completion menu with Kakoune's `<c-o>` command):
+The `lsp-snippets-select-next-placeholders` command allows to jump to the next tabstop (like
+function call arguments). The suggested mapping uses `<tab>` (see <<Configure mappings>>). Here's
+a way to bind it to `<c-n>` instead (might need to hide the completion menu with Kakoune's
+`<c-o>` command):
 
 [source,kak]
 ----
@@ -542,6 +543,7 @@ hook global InsertCompletionHide .* %{
 }
 ----
 
+Snippet support can be disabled by setting `snippet_support = false` at the top level of the config.
 
 == Limitations
 

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -1,4 +1,4 @@
-snippet_support = false
+snippet_support = true
 verbosity = 2
 
 [server]

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -2059,10 +2059,6 @@ map global lsp-selection-range t '<esc>: lsp-selection-range-select top<ret>'   
 map global goto d '<esc>:lsp-definition<ret>' -docstring 'definition'
 map global goto r '<esc>:lsp-references<ret>' -docstring 'references'
 map global goto y '<esc>:lsp-type-definition<ret>' -docstring 'type definition'
-map global object a '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
-map global object <a-a> '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
-map global object e '<a-semicolon>lsp-object Function Method<ret>' -docstring 'LSP function or method'
-map global object k '<a-semicolon>lsp-object Class Interface Struct<ret>' -docstring 'LSP class interface or struct'
 
 ### Default integration ###
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -2056,25 +2056,13 @@ map global lsp-selection-range k '<esc>: lsp-selection-range-select up<ret>'    
 map global lsp-selection-range b '<esc>: lsp-selection-range-select bottom<ret>' -docstring 'select innermost node'
 map global lsp-selection-range t '<esc>: lsp-selection-range-select top<ret>'    -docstring 'select outermost node'
 
-define-command -hidden lsp-mappings-enable -params 1 -docstring "Add LSP mappings to goto and object mode" %{
-    map %arg{1} goto d '<esc>:lsp-definition<ret>' -docstring 'definition'
-    map %arg{1} goto r '<esc>:lsp-references<ret>' -docstring 'references'
-    map %arg{1} goto y '<esc>:lsp-type-definition<ret>' -docstring 'type definition'
-    map %arg{1} object a '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
-    map %arg{1} object <a-a> '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
-    map %arg{1} object e '<a-semicolon>lsp-object Function Method<ret>' -docstring 'LSP function or method'
-    map %arg{1} object k '<a-semicolon>lsp-object Class Interface Struct<ret>' -docstring 'LSP class interface or struct'
-}
-
-define-command -hidden lsp-mappings-disable -params 1 -docstring "Remove LSP mappings from goto and object mode" %{
-    unmap %arg{1} goto d '<esc>:lsp-definition<ret>'
-    unmap %arg{1} goto r '<esc>:lsp-references<ret>'
-    unmap %arg{1} goto y '<esc>:lsp-type-definition<ret>'
-    unmap %arg{1} object a '<a-semicolon>lsp-object<ret>'
-    unmap %arg{1} object <a-a> '<a-semicolon>lsp-object<ret>'
-    unmap %arg{1} object e '<a-semicolon>lsp-object Function Method<ret>'
-    unmap %arg{1} object k '<a-semicolon>lsp-object Class Interface Struct<ret>'
-}
+map global goto d '<esc>:lsp-definition<ret>' -docstring 'definition'
+map global goto r '<esc>:lsp-references<ret>' -docstring 'references'
+map global goto y '<esc>:lsp-type-definition<ret>' -docstring 'type definition'
+map global object a '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
+map global object <a-a> '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
+map global object e '<a-semicolon>lsp-object Function Method<ret>' -docstring 'LSP function or method'
+map global object k '<a-semicolon>lsp-object Class Interface Struct<ret>' -docstring 'LSP class interface or struct'
 
 ### Default integration ###
 
@@ -2089,7 +2077,6 @@ define-command lsp-enable -docstring "Default integration with kak-lsp" %{
     add-highlighter global/lsp_snippets_placeholders ranges lsp_snippets_placeholders
     lsp-inline-diagnostics-enable global
     lsp-diagnostic-lines-enable global
-    lsp-mappings-enable global
 
     set-option global completers option=lsp_completions %opt{completers}
     set-option global lsp_fail_if_disabled nop
@@ -2132,7 +2119,6 @@ define-command lsp-disable -docstring "Disable kak-lsp" %{
     lsp-diagnostic-lines-disable global
     try %{ set-option -remove global completers option=lsp_completions }
     set-option global lsp_fail_if_disabled fail
-    lsp-mappings-disable global
     remove-hooks global lsp
     remove-hooks global lsp-auto-hover
     remove-hooks global lsp-auto-hover-insert-mode
@@ -2155,7 +2141,6 @@ define-command lsp-enable-window -docstring "Default integration with kak-lsp in
 
     lsp-inline-diagnostics-enable window
     lsp-diagnostic-lines-enable window
-    lsp-mappings-enable window
 
     hook -group lsp window WinClose .* lsp-did-close
     hook -group lsp window BufWritePost .* lsp-did-save
@@ -2192,7 +2177,6 @@ define-command lsp-disable-window -docstring "Disable kak-lsp in the window scop
     lsp-diagnostic-lines-disable window
     try %{ set-option -remove window completers option=lsp_completions }
     set-option window lsp_fail_if_disabled fail
-    lsp-mappings-disable window
     remove-hooks window lsp
     remove-hooks global lsp-auto-hover
     remove-hooks global lsp-auto-hover-insert-mode


### PR DESCRIPTION
By convention, Kakoune plugins do not add their own key mappings.
This makes them more predictable and avoids clashes with the user's
mappings.  This is especially important as we add more mappings,
for example the suggested binding for `<tab>`.

Let's add a "suggested mappings" section, so new users are less likely
to skip mapping `<tab>` (which is quite important for snippets).
Keep keys like "gd" to avoid breakage (also no one has complained
about them). Not sure if we should keep the object mode keys.
