### PR TITLE
Recommend mappings to jump to next/previous diagnostic

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -143,6 +143,8 @@ map global object a '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
 map global object <a-a> '<a-semicolon>lsp-object<ret>' -docstring 'LSP any symbol'
 map global object e '<a-semicolon>lsp-object Function Method<ret>' -docstring 'LSP function or method'
 map global object k '<a-semicolon>lsp-object Class Interface Struct<ret>' -docstring 'LSP class interface or struct'
+map global object d '<a-semicolon>lsp-diagnostic-object --include-warnings<ret>' -docstring 'LSP errors and warnings'
+map global object D '<a-semicolon>lsp-diagnostic-object<ret>' -docstring 'LSP errors'
 ----
 
 == Usage
@@ -198,6 +200,7 @@ hook global WinSetOption filetype=rust %{
 ----
 
 * `lsp-object` command to select adjacent or surrounding syntax tree nodes in [object mode](https://github.com/mawww/kakoune/blob/master/doc/pages/modes.asciidoc#object-mode)
+** `lsp-diagnostic-object` does something similar but for inline diagnostics.
 * `lsp-next-symbol` and `lsp-previous-symbol` command to go to the buffer's next and current/previous symbol.
 * `lsp-hover-next-symbol` and `lsp-hover-previous-symbol` to show hover of the buffer's next and current/previous symbol.
 * `lsp-rename <new_name>` and `lsp-rename-prompt` commands to rename the symbol under the main cursor.

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1869,6 +1869,16 @@ define-command -hidden lsp-get-config -params 1 -docstring %{
 
 ### Other commands ###
 
+define-command lsp-diagnostic-object -docstring 'lsp-diagnostic-object [--include-warnings]: go to adjacent diagnostic from object mdoe' -params 0..1 %<
+    evaluate-commands %sh<
+        case "$kak_opt_lsp_object_mode" in
+            ( [ | { | '<a-[>' | '<a-{>' ) previous=--previous ;;
+            (*) previous= ;;
+        esac
+        echo lsp-find-error $previous $1
+    >
+>
+
 define-command lsp-find-error -params 0..2 -docstring "lsp-find-error [--previous] [--include-warnings]
 Jump to the next or previous diagnostic error" %{
     evaluate-commands %sh{


### PR DESCRIPTION
Helix provides a default mapping for jumping to next/previous error. It
is pretty useful when you know that the current buffer has errors,
so we should at least have a recommended mapping.

Add recommended mappings to the object mode. This is a bit hacky
because they don't select _until_ the error but move the entire
selection, independent of object mode key. However it has the advantage
that users are already familiar with choosing a direction with [ or ].
