### PR TITLE
Notify server of workspace changes via workspace/didChangeWatchedFiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +241,15 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -389,6 +410,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +485,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "lsp-types",
+ "notify",
  "pulldown-cmark",
  "rand",
  "regex",
@@ -459,6 +501,26 @@ dependencies = [
  "unindent",
  "url",
  "whoami",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -505,8 +567,7 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.93.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be6e9c7e2d18f651974370d7aff703f9513e0df6e464fd795660edc77e6ca51"
+source = "git+https://github.com/krobelus/lsp-types?branch=hash-file-event#d7219cfaacfe6b6f8e53eb040171f08dc55e4290"
 dependencies = [
  "bitflags",
  "serde",
@@ -534,6 +595,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "notify"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "winapi",
 ]
 
 [[package]]
@@ -752,6 +843,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1138,6 +1238,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,3 +1383,60 @@ dependencies = [
  "widestring",
  "winapi",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ itertools = "0.10.1"
 jsonrpc-core = "18.0.0"
 lazy_static = "1.4.0"
 libc = "0.2.71"
-lsp-types = { version = "0.93.2", features = ["proposed"] }
+lsp-types = { git = "https://github.com/krobelus/lsp-types", branch = "hash-file-event", features = ["proposed"] }
+notify = "5.0.0"
 pulldown-cmark = "0.9.2"
 rand = "0.8.4"
 regex = "1.3.9"

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -68,7 +68,9 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 did_change_configuration: Some(DynamicRegistrationClientCapabilities {
                     dynamic_registration: Some(false),
                 }),
-                did_change_watched_files: None,
+                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                }),
                 symbol: Some(WorkspaceSymbolClientCapabilities {
                     dynamic_registration: Some(false),
                     symbol_kind: symbol_kind_capability.clone(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,4 @@
+use crate::text_sync::CompiledFileSystemWatcher;
 use crate::types::*;
 use crossbeam_channel::Sender;
 use jsonrpc_core::{self, Call, Error, Failure, Id, Output, Success, Value, Version};
@@ -51,6 +52,7 @@ pub struct Context {
     pub preferred_offset_encoding: Option<OffsetEncoding>,
     pub work_done_progress: HashMap<NumberOrString, Option<WorkDoneProgressBegin>>,
     pub work_done_progress_report_timestamp: time::Instant,
+    pub pending_file_watchers: Vec<CompiledFileSystemWatcher>,
 }
 
 pub struct ContextBuilder {
@@ -89,6 +91,7 @@ impl Context {
             preferred_offset_encoding: params.offset_encoding,
             work_done_progress: HashMap::default(),
             work_done_progress_report_timestamp: time::Instant::now(),
+            pending_file_watchers: vec![],
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -53,38 +53,40 @@ pub struct Context {
     pub work_done_progress_report_timestamp: time::Instant,
 }
 
+pub struct ContextBuilder {
+    pub language_id: String,
+    pub initial_request: EditorRequest,
+    pub lang_srv_tx: Sender<ServerMessage>,
+    pub editor_tx: Sender<EditorResponse>,
+    pub config: Config,
+    pub root_path: String,
+    pub offset_encoding: Option<OffsetEncoding>,
+}
+
 impl Context {
-    pub fn new(
-        language_id: &str,
-        initial_request: EditorRequest,
-        lang_srv_tx: Sender<ServerMessage>,
-        editor_tx: Sender<EditorResponse>,
-        config: Config,
-        root_path: String,
-        offset_encoding: Option<OffsetEncoding>,
-    ) -> Self {
-        let session = initial_request.meta.session.clone();
+    pub fn new(params: ContextBuilder) -> Self {
+        let session = params.initial_request.meta.session.clone();
         Context {
             batch_counter: 0,
             batches: HashMap::default(),
             capabilities: None,
             completion_items: vec![],
             completion_last_client: None,
-            config,
+            config: params.config,
             dynamic_config: DynamicConfig::default(),
             diagnostics: HashMap::default(),
             code_lenses: HashMap::default(),
-            editor_tx,
-            lang_srv_tx,
-            language_id: language_id.to_string(),
-            pending_requests: vec![initial_request],
+            editor_tx: params.editor_tx,
+            lang_srv_tx: params.lang_srv_tx,
+            language_id: params.language_id,
+            pending_requests: vec![params.initial_request],
             request_counter: 0,
             response_waitlist: HashMap::default(),
-            root_path,
+            root_path: params.root_path,
             session,
             documents: HashMap::default(),
-            offset_encoding: offset_encoding.unwrap_or(OffsetEncoding::Utf16),
-            preferred_offset_encoding: offset_encoding,
+            offset_encoding: params.offset_encoding.unwrap_or(OffsetEncoding::Utf16),
+            preferred_offset_encoding: params.offset_encoding,
             work_done_progress: HashMap::default(),
             work_done_progress_report_timestamp: time::Instant::now(),
         }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -72,15 +72,15 @@ pub fn start(
     initial_request_meta.fifo = None;
     initial_request_meta.write_response_to_fifo = false;
 
-    let mut ctx = Context::new(
-        &route.language,
+    let mut ctx = Context::new(ContextBuilder {
+        language_id: route.language.clone(),
         initial_request,
-        lang_srv.to_lang_server.sender().clone(),
-        to_editor,
+        lang_srv_tx: lang_srv.to_lang_server.sender().clone(),
+        editor_tx: to_editor,
         config,
-        route.root.clone(),
+        root_path: route.root.clone(),
         offset_encoding,
-    );
+    });
 
     initialize(&route.root, initial_request_meta.clone(), &mut ctx);
 

--- a/src/text_sync.rs
+++ b/src/text_sync.rs
@@ -1,8 +1,14 @@
+use std::path::Path;
+
 use crate::context::*;
 use crate::language_features::code_lens::text_document_code_lens;
+use crate::thread_worker::Worker;
 use crate::types::*;
+use crossbeam_channel::{Receiver, Sender};
+use jsonrpc_core::Value;
 use lsp_types::notification::*;
 use lsp_types::*;
+use notify::{RecursiveMode, Watcher};
 use ropey::Rope;
 use serde::Deserialize;
 use url::Url;
@@ -92,4 +98,133 @@ pub fn text_document_did_save(meta: EditorMeta, ctx: &mut Context) {
         text,
     };
     ctx.notify::<DidSaveTextDocument>(params);
+}
+
+pub fn spawn_file_watcher(
+    root_path: String,
+    watch_requests: Vec<CompiledFileSystemWatcher>,
+) -> Worker<(), Vec<FileEvent>> {
+    info!("starting file watcher");
+    Worker::spawn(
+        "File system change watcher",
+        1024, // arbitrary
+        move |receiver: Receiver<()>, sender: Sender<Vec<FileEvent>>| {
+            let callback = move |res: notify::Result<notify::Event>| {
+                match res {
+                    Ok(event) => {
+                        let file_changes = event_file_changes(&watch_requests, event);
+                        if !file_changes.is_empty() {
+                            if let Err(err) = sender.send(file_changes) {
+                                error!("{}", err);
+                            }
+                        }
+                    }
+                    Err(e) => error!("{}", e),
+                };
+            };
+            let mut watcher = match notify::recommended_watcher(callback) {
+                Ok(watcher) => watcher,
+                Err(err) => {
+                    error!("{}", err);
+                    return;
+                }
+            };
+            let path = Path::new(&root_path);
+            if let Err(err) = watcher.watch(path, RecursiveMode::Recursive) {
+                error!("{}", err);
+            }
+            if let Err(err) = receiver.recv() {
+                error!("{}", err);
+            }
+        },
+    )
+}
+
+fn event_file_changes(
+    // sender: Sender<Vec<FileEvent>>,
+    watch_requests: &Vec<CompiledFileSystemWatcher>,
+    event: notify::Event,
+) -> Vec<FileEvent> {
+    let mut file_changes = vec![];
+
+    for path in &event.paths {
+        for watch_request in watch_requests {
+            let watch_kind = watch_request.kind;
+            let file_change_type = match event.kind {
+                notify::EventKind::Create(_) => {
+                    if !watch_kind.contains(WatchKind::Create) {
+                        continue;
+                    }
+                    FileChangeType::CREATED
+                }
+                notify::EventKind::Modify(_) => {
+                    if !watch_kind.contains(WatchKind::Change) {
+                        continue;
+                    }
+                    FileChangeType::CHANGED
+                }
+                notify::EventKind::Remove(_) => {
+                    if !watch_kind.contains(WatchKind::Delete) {
+                        continue;
+                    }
+                    FileChangeType::DELETED
+                }
+                notify::EventKind::Any
+                | notify::EventKind::Access(_)
+                | notify::EventKind::Other => continue,
+            };
+            if watch_request.pattern.matches_path(path) {
+                file_changes.push(FileEvent {
+                    uri: Url::from_file_path(&path).unwrap(),
+                    typ: file_change_type,
+                });
+                break;
+            }
+        }
+    }
+    file_changes
+}
+
+pub fn workspace_did_change_watched_files(changes: Vec<FileEvent>, ctx: &mut Context) {
+    let params = DidChangeWatchedFilesParams { changes };
+    ctx.notify::<DidChangeWatchedFiles>(params);
+}
+
+#[derive(Clone)]
+pub struct CompiledFileSystemWatcher {
+    kind: WatchKind,
+    pattern: glob::Pattern,
+}
+
+pub fn register_workspace_did_change_watched_files(options: Option<Value>, ctx: &mut Context) {
+    let options = options.unwrap();
+    let options = DidChangeWatchedFilesRegistrationOptions::deserialize(options).unwrap();
+    let watchers = options
+        .watchers
+        .into_iter()
+        .filter_map(|watcher| {
+            if watcher.glob_pattern.contains('{') {
+                error!(
+                    "unsupported braces in glob patttern: '{}'",
+                    &watcher.glob_pattern
+                );
+                return None;
+            }
+            let pattern = match glob::Pattern::new(&watcher.glob_pattern) {
+                Ok(pattern) => pattern,
+                Err(err) => {
+                    error!(
+                        "failed to compile glob pattern '{}': {}",
+                        &watcher.glob_pattern, err
+                    );
+                    return None;
+                }
+            };
+            let default_watch_kind = WatchKind::Create | WatchKind::Change | WatchKind::Delete;
+            let kind = watcher.kind.unwrap_or(default_watch_kind);
+            Some(CompiledFileSystemWatcher { kind, pattern })
+        })
+        .collect();
+    assert!(ctx.pending_file_watchers.is_empty());
+    ctx.pending_file_watchers = watchers;
 }


### PR DESCRIPTION
Some language servers request to be notified of changes files in the
workspace (even if they are not open by the editor). This includes
build configuration files like Cargo.toml, for which we currently do
not send any notification, not even when it's opened by the editor.

Fix these problems for the common cases by watching the entire root
path recursively for file change events and forward them to the server.
Batch event notifications that arrive within a window of 500
milliseconds, to reduce traffic in the event of a "git checkout"
or "git rebase".

This feature might cause performance problems on large worktrees.

Tested with rust-analyzer, are there any other servers that request
these file change notifications?

This means we send duplicate change notifications when saving a file
(since we also send "textDocument/didSave"). We can probably worry
about cleaning this up later.

The implementation uses a separate thread which might be unnecessary
but adding watches for a large directory might take a while (untested).
A better solution would be retire the thread after it has added
watches. Haven't gotten around to that yet.

Closes #649
