### PR TITLE
latex: update links to texlab docs which were moved to wiki

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -222,10 +222,10 @@ roots = [".git", ".hg"]
 command = "texlab"
 settings_section = "texlab"
 [language.latex.settings.texlab]
-# See https://github.com/latex-lsp/texlab/blob/master/docs/options.md
+# See https://github.com/latex-lsp/texlab/wiki/Configuration
 #
 # Preview configuration for zathura with SyncTeX search.
-# For other PDF viewers see https://github.com/latex-lsp/texlab/blob/master/docs/previewing.md
+# For other PDF viewers see https://github.com/latex-lsp/texlab/wiki/Previewing
 forwardSearch.executable = "zathura"
 forwardSearch.args = [
     "%p",


### PR DESCRIPTION
The links old links that are in the comment were leading to 404 error