### PR TITLE
Allow lsp-goto-document-symbol to take a param

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -920,7 +920,7 @@ ${kak_opt_lsp_connect_fifo}\
 " | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
-define-command lsp-goto-document-symbol -docstring "Jump to any symbol from current buffer" %{
+define-command lsp-goto-document-symbol -params 0..1 -docstring "Jump to any symbol from current buffer" %{
     nop %sh{ (printf %s "
 session  = \"${kak_session}\"
 client   = \"${kak_client}\"
@@ -931,6 +931,7 @@ method   = \"kak-lsp/goto-document-symbol\"
 $([ -z ${kak_hook_param+x} ] || echo hook = true)
 ${kak_opt_lsp_connect_fifo}\
 [params]
+$([ \"\" = \"${1:-}\" ] || echo goto_symbol = \"${1}\")
 " | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -271,6 +271,11 @@ pub struct NextOrPrevSymbolParams {
 }
 
 #[derive(Clone, Deserialize, Debug)]
+pub struct GotoSymbolParams {
+    pub goto_symbol: Option<String>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
 pub struct ObjectParams {
     pub count: u32,
     pub mode: String,


### PR DESCRIPTION
Here is something I hacked up for myself and I think might be useful to kak-lsp.

This PR allows `lsp-goto-document-symbol` to take a parameter. Right now you do `:lsp-goto-document-symbol<ret>`, wait for a menu to appear and then choose the name of the symbol you want to go to.

After this PR, you can optionally add the symbol name of the symbol you want to go to to the command, if you already know it. 

Example: `:lsp-goto-document-symbol foo_bar<ret>` will take you to the `foo_bar` symbol in the document, if it exists.

This functionality allows some pretty useful use cases, one of which I am using now and which was why I built the functionality in the first place.

For example in OCaml you need to frequently switch between `ml` and `mli` files by using `:alt`. However, this is only partially useful because it would be nice to actually land up the cursor on correct function when you switch between `ml` and `mli`.

Given this PR, this functionality becomes quite easy to accomplish.

```kak
define-command ocaml-switch-def %{
     evaluate-commands -save-regs %{a} %{
         try %{
             execute-keys <a-i>w"ay
             alt
             lsp-goto-document-symbol %reg{a}
         }
     }
}
```

----
As mentioned, I hacked this up reasonably quickly and am sharing in the hope that it might be useful to the kak-lsp community. If you think this is useful and a few small changes can help this get "over the line" please let me know and I'll be happy to make those changes. 

I may not have the time for larger changes in case you feel the overall approach of the PR needs a significant overhaul.