### PR TITLE
Implement `window/showMessageRequest`

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -128,6 +128,11 @@ info=$lsp_info \
             lines++
         }
 
+        if (ENVIRON["kak_opt_lsp_modeline_message_requests"]) {
+            r = r "There are unread messages (use lsp-show-message-request-next to read)\n"
+            lines++
+        }
+
         info_lines = split(info, info_line, /\n/)
         for (i = 1; i <= info_lines && (max_lines <= 0 || i+lines+2 <= max_lines); i++)
             print info_line[i]

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -207,6 +207,7 @@ define-command -hidden lsp-menu -params 1.. -docstring "Like menu but with promp
                     esac
                 ¶
             §" "$cases"
+            printf ' %s' "$on_abort"
             printf ' -menu -shell-script-candidates %%§
                 printf %%s %s
                 §\n' "$(shellquote "$completion")"

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1764,7 +1764,7 @@ client   = \"${kak_client}\"
 buffile  = \"${kak_buffile}\"
 filetype = \"${kak_opt_filetype}\"
 version  = ${kak_timestamp:-0}
-method   = \"window/showMessageRequest\"
+method   = \"window/showMessageRequest/showNext\"
 $([ -z ${kak_hook_param+x} ] || echo hook = true)
 ${kak_opt_lsp_connect_fifo}\
 [params]
@@ -1778,7 +1778,7 @@ client   = \"${kak_client}\"
 buffile  = \"${kak_buffile}\"
 filetype = \"${kak_opt_filetype}\"
 version  = ${kak_timestamp:-0}
-method   = \"window/showMessageRequest\"
+method   = \"window/showMessageRequest/respond\"
 $([ -z ${kak_hook_param+x} ] || echo hook = true)
 ${kak_opt_lsp_connect_fifo}\
 [params]

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -179,7 +179,7 @@ define-command -hidden lsp-menu -params 1.. -docstring "Like menu but with promp
             }
             on_abort=
             if [ $1 = "-on-abort" ]; then
-                ob_abort="-on-abort $(shellquote "$2" s/¶/¶¶/g)"
+                on_abort="-on-abort $(shellquote "$2" s/¶/¶¶/g)"
                 shift 2
             fi
             cases=
@@ -1745,16 +1745,16 @@ define-command -hidden lsp-show-message-request -params 4.. -docstring %{
     Render a prompt message with options.
 } %{
     evaluate-commands -try-client %opt{toolsclient} %{
-        info -title "From LSP" %arg{1}
+        info -title "From language server" %arg{1}
         evaluate-commands %sh{
             on_abort="$2"
             shift 2
-            echo lsp-menu -on-abort $on_abort "$@"
+            echo lsp-menu -on-abort "$on_abort" "$@"
         }
     }
 }
 
-define-command lsp-show-message-request-next -params 0 -docstring %{
+define-command lsp-show-message-request-next -docstring %{
     lsp-show-message-request-next
     Show the next pending message request.
 } %{

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -309,7 +309,7 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
                 work_done_progress: Some(true),
                 show_message: Some(ShowMessageRequestClientCapabilities {
                     message_action_item: Some(MessageActionItemCapabilities {
-                        additional_properties_support: Some(false),
+                        additional_properties_support: Some(true),
                     }),
                 }),
                 show_document: None,

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use lsp_types::*;
 use serde::Deserialize;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::path::PathBuf;
 use std::{fs, time};
@@ -53,6 +53,7 @@ pub struct Context {
     pub language_id: String,
     pub outstanding_requests: HashMap<(&'static str, String, Option<String>), OutstandingRequests>,
     pub pending_requests: Vec<EditorRequest>,
+    pub pending_message_requests: VecDeque<(Id, ShowMessageRequestParams)>,
     pub request_counter: u64,
     pub response_waitlist: HashMap<Id, (EditorMeta, &'static str, BatchNumber, bool)>,
     pub root_path: String,
@@ -94,6 +95,7 @@ impl Context {
             language_id: params.language_id,
             outstanding_requests: HashMap::default(),
             pending_requests: vec![params.initial_request],
+            pending_message_requests: VecDeque::new(),
             request_counter: 0,
             response_waitlist: HashMap::default(),
             root_path: params.root_path,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -459,8 +459,11 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
             inlay_hints::inlay_hints(meta, params, ctx);
         }
 
-        request::ShowMessageRequest::METHOD => {
-            show_message::show_message_request_respond(meta, params, ctx);
+        show_message::SHOW_MESSAGE_REQUEST_NEXT => {
+            show_message::show_message_request_next(meta, ctx);
+        }
+        show_message::SHOW_MESSAGE_REQUEST_RESPOND => {
+            show_message::show_message_request_respond(params, ctx);
         }
 
         // CCLS

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -588,7 +588,7 @@ fn dispatch_server_notification(meta: EditorMeta, method: &str, params: Params, 
             let params: ShowMessageParams = params
                 .parse()
                 .expect("Failed to parse ShowMessageParams params");
-            show_message::show_message(meta, params, ctx);
+            show_message::show_message(meta, params.typ, &params.message, ctx);
         }
         "window/logMessage" => {
             let params: LogMessageParams = params

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -11,6 +11,7 @@ use crate::diagnostics;
 use crate::language_features::{selection_range, *};
 use crate::language_server_transport;
 use crate::progress;
+use crate::show_message;
 use crate::text_sync::*;
 use crate::thread_worker::Worker;
 use crate::types::*;
@@ -129,7 +130,7 @@ pub fn start(
                     ServerMessage::Request(call) => {
                         match call {
                             Call::MethodCall(request) => {
-                              dispatch_server_request(request, &mut ctx);
+                              dispatch_server_request(initial_request_meta.clone(), request, &mut ctx);
                             }
                             Call::Notification(notification) => {
                                 dispatch_server_notification(
@@ -458,6 +459,10 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
             inlay_hints::inlay_hints(meta, params, ctx);
         }
 
+        request::ShowMessageRequest::METHOD => {
+            show_message::show_message_request_respond(meta, params, ctx);
+        }
+
         // CCLS
         ccls::NavigateRequest::METHOD => {
             ccls::navigate(meta, params, ctx);
@@ -504,7 +509,7 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) {
     }
 }
 
-fn dispatch_server_request(request: MethodCall, ctx: &mut Context) {
+fn dispatch_server_request(meta: EditorMeta, request: MethodCall, ctx: &mut Context) {
     let method: &str = &request.method;
     let result = match method {
         request::ApplyWorkspaceEdit::METHOD => {
@@ -545,6 +550,9 @@ fn dispatch_server_request(request: MethodCall, ctx: &mut Context) {
             progress::work_done_progress_create(request.params, ctx)
         }
         request::WorkspaceConfiguration::METHOD => workspace::configuration(request.params, ctx),
+        request::ShowMessageRequest::METHOD => {
+            return show_message::show_message_request(meta, request, ctx);
+        }
         _ => {
             warn!("Unsupported method: {}", method);
             Err(jsonrpc_core::Error::new(
@@ -577,20 +585,7 @@ fn dispatch_server_notification(meta: EditorMeta, method: &str, params: Params, 
             let params: ShowMessageParams = params
                 .parse()
                 .expect("Failed to parse ShowMessageParams params");
-            let command = match params.typ {
-                MessageType::ERROR => "lsp-show-message-error",
-                MessageType::WARNING => "lsp-show-message-warning",
-                MessageType::INFO => "lsp-show-message-info",
-                MessageType::LOG => "lsp-show-message-log",
-                _ => {
-                    warn!("Unexpected ShowMessageParams type: {:?}", params.typ);
-                    "nop"
-                }
-            };
-            ctx.exec(
-                meta,
-                format!("{} {}", command, editor_quote(&params.message)),
-            );
+            show_message::show_message(meta, params, ctx);
         }
         "window/logMessage" => {
             let params: LogMessageParams = params

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod progress;
 mod project_root;
 mod session;
 mod settings;
+mod show_message;
 mod text_edit;
 mod text_sync;
 mod thread_worker;

--- a/src/show_message.rs
+++ b/src/show_message.rs
@@ -1,0 +1,137 @@
+use std::borrow::Cow;
+
+use itertools::Itertools;
+use jsonrpc_core::{Id, MethodCall};
+use lsp_types::{MessageActionItem, MessageType, ShowMessageParams, ShowMessageRequestParams};
+use serde::Deserialize;
+
+use crate::{context::Context, types::EditorMeta, util::editor_quote};
+
+/// Queues the message request from the LSP server.
+pub fn show_message_request(meta: EditorMeta, request: MethodCall, ctx: &mut Context) {
+    let params: ShowMessageRequestParams = request
+        .params
+        .clone()
+        .parse()
+        .expect("Failed to parse ShowMessageRequest params");
+    ctx.pending_message_requests.push_back((request.id, params));
+    update_modeline(meta, ctx)
+}
+
+#[derive(Deserialize)]
+struct MessageRequestResponse {
+    pub message_request_id: Option<Id>,
+    pub item: Option<toml::Value>,
+}
+
+/// Handles an user's response to a message request (or the user's request to display the next message request).
+pub fn show_message_request_respond(meta: EditorMeta, params: toml::Value, ctx: &mut Context) {
+    let resp =
+        MessageRequestResponse::deserialize(params).expect("Cannot parse message request response");
+    let req_id = match resp.message_request_id {
+        None => return show_message_request_next(meta, ctx),
+        Some(id) => id,
+    };
+    let item = resp
+        .item
+        .and_then(|v| MessageActionItem::deserialize(v).ok())
+        .map(|v| jsonrpc_core::to_value(v).expect("Cannot serialize item"))
+        .unwrap_or(jsonrpc_core::Value::Null);
+    ctx.reply(req_id, Ok(item));
+}
+
+fn show_message_request_next(meta: EditorMeta, ctx: &mut Context) {
+    let (id, params) = match ctx.pending_message_requests.pop_front() {
+        Some(v) => v,
+        None => {
+            return ctx.exec(meta, "lsp-show-error 'No pending message requests.'");
+        }
+    };
+
+    let options = match &params.actions {
+        Some(opts) if !opts.is_empty() => &opts[..],
+        _ => {
+            // a ShowMessageRequest with no actions is just a ShowMessage notification.
+            show_message(
+                meta,
+                ShowMessageParams {
+                    typ: params.typ,
+                    message: params.message,
+                },
+                ctx,
+            );
+            ctx.reply(id, Ok(serde_json::Value::Null));
+            return;
+        }
+    };
+    let request_id = editor_quote(
+        toml::to_string(&id)
+            .expect("cannot convert request id to toml")
+            .as_ref(),
+    );
+    let option_menu_opts = options
+        .iter()
+        .flat_map(|item| {
+            let cmd = format!(
+                "%{{lsp-show-message-request-respond {} {}}}",
+                request_id,
+                editor_quote(
+                    toml::to_string(item)
+                        .expect("cannot convert message action to toml")
+                        .as_ref()
+                )
+            );
+            [editor_quote(item.title.as_ref()), cmd]
+        })
+        .map(|v| editor_quote(v.as_ref())) // double quoting for request passing
+        .join(" ");
+    // send the command to the editor
+    ctx.exec(
+        meta.clone(),
+        format!(
+            "lsp-show-message-request {} {} {}",
+            editor_quote(params.message.as_ref()),
+            editor_quote(format!("%{{lsp-show-message-request-respond {}}}", request_id).as_ref()),
+            option_menu_opts
+        ),
+    );
+    update_modeline(meta, ctx);
+}
+
+/// Implements ShowMessage notification.
+pub fn show_message(meta: EditorMeta, params: ShowMessageParams, ctx: &Context) {
+    let command = message_type(params.typ).unwrap_or("nop");
+    ctx.exec(
+        meta,
+        format!("{} {}", command, editor_quote(&params.message)),
+    );
+}
+
+fn update_modeline(meta: EditorMeta, ctx: &Context) {
+    let modeline = if ctx.pending_message_requests.is_empty() {
+        Cow::from("")
+    } else {
+        Cow::from(format!("🔔{}", ctx.pending_message_requests.len()))
+    };
+
+    ctx.exec(
+        meta,
+        format!(
+            "set-option global lsp_modeline_message_requests {}",
+            editor_quote(modeline.as_ref()),
+        ),
+    );
+}
+
+fn message_type(typ: MessageType) -> Option<&'static str> {
+    Some(match typ {
+        MessageType::ERROR => "lsp-show-message-error",
+        MessageType::WARNING => "lsp-show-message-warning",
+        MessageType::INFO => "lsp-show-message-info",
+        MessageType::LOG => "lsp-show-message-log",
+        _ => {
+            warn!("Unexpected ShowMessageParams type: {:?}", typ);
+            return None;
+        }
+    })
+}


### PR DESCRIPTION
Implement [`window/showMessageRequest`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest). Closes #183.

- Adds a new modeline option, `lsp_modeline_message_requests`, that displays the
number of pending message requests on the modeline, as a bell + number of requests.
- A new user-facing command, `lsp-show-message-request-next`, pops and shows the
next pending request.

- The requests are stored in a queue (a `VecDeque`) in the context.
- We display the message and the prompt by an `info` + `lsp-menu` call.
- Responses to the request are made by the menu calling back with `lsp-show-message-request-respond`.

