### PR TITLE
Change roots for Haskell

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -112,7 +112,7 @@ settings_section = "gopls"
 
 [language.haskell]
 filetypes = ["haskell"]
-roots = ["Setup.hs", "stack.yaml", "*.cabal"]
+roots = ["hie.yaml", "cabal.project", "Setup.hs", "stack.yaml", "*.cabal"]
 command = "haskell-language-server-wrapper"
 args = ["--lsp"]
 settings_section = "_"


### PR DESCRIPTION
In the case of GHC, the root would be incorrectly detected, leading to a non-functional HLS instance. `hie.yaml` and `cabal.project` are AFAICT the most reliable indicators of where the project root is.