### PR TITLE
kak-lsp.toml: Improve `roots` for OCaml

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -264,7 +264,8 @@ command = "rnix-lsp"
 
 [language.ocaml]
 filetypes = ["ocaml"]
-roots = ["Makefile", "opam", "*.opam", "dune"]
+# Often useful to simply do a `touch dune-workspace` in your project root folder if you have problems with root detection
+roots = ["dune-workspace", "dune-project", "Makefile", "opam", "*.opam", "esy.json", ".git", ".hg", "dune"]
 command = "ocamllsp"
 
 [language.php]


### PR DESCRIPTION
For instance, seeing a `dune-workspace` file is a very good indicator to have found the project root. OTOH seeing a `dune` file is a not a good indication of being in the root as dune files will often appear  much below the root.