### PR TITLE
update to crossbeam-channel v0.5.8 as v0.5.6 in the `crates-io` registry is yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",


### PR DESCRIPTION
update to crossbeam-channel v0.5.8 as v0.5.6 in the `crates-io` registry is yanked

Fix for:
```
$ cargo install --path . --locked
  Installing kak-lsp v14.2.0-snapshot (/home/abcxyz123/kak-lsp)
    Updating crates.io index
warning: package `crossbeam-channel v0.5.6` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
 ...
```