### PR TITLE
Handle multiple servers per language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Additions:
+- Support multiple language servers per filetype (#17).
+- The `kak-lsp.toml` format for specifying language servers has changed. The old format is still supported (#686).
+
 Fixes:
 - A regression broke resolving completion item documentation when cycling through completion candidates, which has been fixed (#674).
 - New command `lsp-declaration`, implementing `textDocument/declaration`.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -304,22 +304,52 @@ Please let us know if you have any ideas about how to make the default config mo
 ==== Server-specific configuration
 
 Many servers accept configuration options that are not part of the LSP spec.  The TOML table
-`[language.<filetype>.settings]` holds those configuration options.  It has the same structure
+`[language_server.<server_name>.settings]` holds those configuration options.  It has the same structure
 as the corresponding fragments from VSCode's `settings.json`. For example:
 
 [source,toml]
 ----
-[language.go]
+[language_server.gopls]
 ...
-settings_section = "gopls"
-[language.go.settings.gopls]
+settings_section = "gopls" # Optional, defaults to server name.
+[language_server.gopls.settings.gopls]
 "formatting.gofumpt" = true
 ----
 
-During server initialization, kak-lsp sends the section specified by `settings_section`; in this
-case `{"formatting.gofumpt":true}`.  Whenever you change the Kakoune option `lsp_config`, the
-same section is sent via `workspace/didChangeConfiguration`.  Additionally, kak-lsp will send
-arbitrary sections that are requested by the server in `workspace/configuration`.
+During server initialization, kak-lsp sends either the section specified by `settings_section`.
+or the section with same name as the server; in this case `{"formatting.gofumpt":true}`.
+Whenever you change the Kakoune option `lsp_config`, the same section is sent via
+`workspace/didChangeConfiguration`.  Additionally, kak-lsp will send arbitrary sections that
+are requested by the server in `workspace/configuration`.
+
+==== Multiple language servers
+
+It is possible to map more than one language server to a filetype. For example, if you want to
+set up TSServer and TailwindCSS to use in React projects:
+
+[source,toml]
+----
+[language_ids]
+javascript = "javascriptreact"
+typescript = "typescriptreact"
+
+[language_server.tsserver]
+filetypes = ["javascript", "typescript"]
+roots = ["package.json", "tsconfig.json", "jsconfig.json", ".git", ".hg"]
+command = "typescript-language-server"
+args = ["--stdio"]
+
+[language_server.tailwindcss]
+filetypes = ["javascript", "typescript"]
+roots = ["tailwind.config.ts", "tailwind.config.js"]
+command = "tailwindcss-language-server"
+args = ["--stdio"]
+[language_server.tailwindcss.settings.tailwindcss]
+editor = {}
+----
+
+Note that, just like in the config above, it is possible to override the language ID sent to
+the language server by mapping filetypes using `language_ids`.
 
 === Configuring Kakoune
 
@@ -334,14 +364,14 @@ kak-lsp's Kakoune integration declares the following options:
 * `lsp_auto_highlight_references` (bool): If this option is `true` then `lsp-highlight-references` is executed every time the user pauses in normal mode.
 * `lsp_auto_show_code_actions` (bool): If this option is `true` then `lsp-code-actions` is executed every time the user pauses in normal mode.
 * `lsp_config` (str): This is a TOML string of the same format as `kak-lsp.toml`, except it currently only supports one kind of configuration value:
-** `[language.<filetype>.settings]`: this works just like the static configuration of the same name in `kak-lsp.toml`, see the section about server-specific configuration. This will override the static configuration of the given language.
+** `[language_server.<server_name>.settings]`: this works just like the static configuration of the same name in `kak-lsp.toml`, see the section about server-specific configuration. This will override the static configuration of the given language server.
 
 For example, you can toggle an option dynamically with a command like this:
 
 [source,kak]
 ----
 set-option global lsp_config %{
-    [language.go.settings.gopls]
+    [language_server.gopls.settings.gopls]
     "formatting.gofumpt" = true
 }
 ----

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -6,129 +6,90 @@ verbosity = 2
 # set to 0 to disable
 timeout = 1800 # seconds = 30 minutes
 
-[language.bash]
+# This section overrides language IDs.
+# By default, kak-lsp use filetypes for the IDs.
+# See https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentItem
+[language_ids]
+c = "c_cpp"
+cpp = "c_cpp"
+javascript = "javascriptreact"
+typescript = "typescriptreact"
+protobuf = "proto"
+sh = "shellscript"
+
+[language_server.bash-language-server]
 filetypes = ["sh"]
 roots = [".git", ".hg"]
 command = "bash-language-server"
 args = ["start"]
 
-[language.c_cpp]
+[language_server.clangd]
 filetypes = ["c", "cpp"]
 roots = ["compile_commands.json", ".clangd", ".git", ".hg"]
 command = "clangd"
 
-[language.clojure]
+[language_server.clojure-lsp]
 filetypes = ["clojure"]
 roots = ["project.clj", ".git", ".hg"]
 command = "clojure-lsp"
 settings_section = "_"
-[language.clojure.settings._]
+[language_server.clojure-lsp.settings._]
 # See https://clojure-lsp.io/settings/#all-settings
 # source-paths-ignore-regex = ["resources.*", "target.*"]
 
-[language.cmake]
+[language_server.cmake-language-server]
 filetypes = ["cmake"]
 roots = ["CMakeLists.txt", ".git", ".hg"]
 command = "cmake-language-server"
 
-[language.crystal]
+[language_server.crystalline]
 filetypes = ["crystal"]
 roots = ["shard.yml"]
 command = "crystalline"
 
-[language.css]
+[language_server.css-language-server]
 filetypes = ["css"]
 roots = ["package.json", ".git", ".hg"]
 command = "vscode-css-languageserver"
 args = ["--stdio"]
 
-[language.less]
+# [language_server.deno-lsp]
+# filetypes = ["javascript", "typescript"]
+# roots = ["package.json", "tsconfig.json", ".git", ".hg"]
+# command = "deno"
+# args = ["lsp"]
+# settings_section = "deno"
+# [language_server.deno-lsp.settings.deno]
+# enable = true
+# lint = true
+
+[language_server.less-language-server]
 filetypes = ["less"]
 roots = ["package.json", ".git", ".hg"]
 command = "vscode-css-languageserver"
 args = ["--stdio"]
 
-[language.scss]
+[language_server.scss-language-server]
 filetypes = ["scss"]
 roots = ["package.json", ".git", ".hg"]
 command = "vscode-css-languageserver"
 args = ["--stdio"]
 
-[language.d]
+[language_server.dls]
 filetypes = ["d", "di"]
 roots = [".git", "dub.sdl", "dub.json"]
 command = "dls"
 
-[language.dart]
+[language_server.dart-lsp]
 # start shell to find path to dart analysis server source
 filetypes = ["dart"]
 roots = ["pubspec.yaml", ".git", ".hg"]
 command = "sh"
 args = ["-c", "dart $(dirname $(command -v dart))/snapshots/analysis_server.dart.snapshot --lsp"]
 
-[language.elixir]
-filetypes = ["elixir"]
-roots = ["mix.exs"]
-command = "elixir-ls"
-settings_section = "elixirLS"
-[language.elixir.settings.elixirLS]
-# See https://github.com/elixir-lsp/elixir-ls/blob/master/apps/language_server/lib/language_server/server.ex
-# dialyzerEnable = true
-
-[language.elm]
-filetypes = ["elm"]
-roots = ["elm.json"]
-command = "elm-language-server"
-args = ["--stdio"]
-settings_section = "elmLS"
-[language.elm.settings.elmLS]
-# See https://github.com/elm-tooling/elm-language-server#server-settings
-runtime = "node"
-elmPath = "elm"
-elmFormatPath = "elm-format"
-elmTestPath = "elm-test"
-
-[language.elvish]
-filetypes = ["elvish"]
-roots = [".git", ".hg"]
-command = "elvish"
-args = ["-lsp"]
-
-[language.erlang]
-filetypes = ["erlang"]
-# See https://github.com/erlang-ls/erlang_ls.git for more information and
-# how to configure. This default config should work in most cases though.
-roots = ["rebar.config", "erlang.mk", ".git", ".hg"]
-command = "erlang_ls"
-
-[language.go]
-filetypes = ["go"]
-roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
-command = "gopls"
-settings_section = "gopls"
-[language.go.settings.gopls]
-# See https://github.com/golang/tools/blob/master/gopls/doc/settings.md
-# "build.buildFlags" = []
-
-[language.haskell]
-filetypes = ["haskell"]
-roots = ["hie.yaml", "cabal.project", "Setup.hs", "stack.yaml", "*.cabal"]
-command = "haskell-language-server-wrapper"
-args = ["--lsp"]
-settings_section = "_"
-[language.haskell.settings._]
-# See https://haskell-language-server.readthedocs.io/en/latest/configuration.html
-# haskell.formattingProvider = "ormolu"
-
-[language.html]
-filetypes = ["html"]
-roots = ["package.json"]
-command = "vscode-html-languageserver"
-args = ["--stdio"]
-
 # # Commented out by default because you still need to set the paths in the JDT
 # # Language Server arguments below before this can become a valid configuration.
-# [language.java]
+# [language_server.ejdtls]
 # filetypes = ["java"]
 # roots = [".git", "mvnw", "gradlew"]
 # command = "java"
@@ -152,21 +113,83 @@ args = ["--stdio"]
 #     "-data",
 #     "/path/to/eclipse-workspace",
 # ]
-# [language.java.settings]
+# [language_server.ejdtls.settings]
 # # See https://github.dev/eclipse/eclipse.jdt.ls
 # # "java.format.insertSpaces" = true
 
-[language.javascriptreact]
-filetypes = ["javascript"]
-roots = ["package.json", "tsconfig.json", ".git", ".hg"]
-command = "typescript-language-server"
+[language_server.elixir-ls]
+filetypes = ["elixir"]
+roots = ["mix.exs"]
+command = "elixir-ls"
+settings_section = "elixirLS"
+[language_server.elixir-ls.settings.elixirLS]
+# See https://github.com/elixir-lsp/elixir-ls/blob/master/apps/language_server/lib/language_server/server.ex
+# dialyzerEnable = true
+
+[language_server.elm-language-server]
+filetypes = ["elm"]
+roots = ["elm.json"]
+command = "elm-language-server"
+args = ["--stdio"]
+settings_section = "elmLS"
+[language_server.elm-language-server.settings.elmLS]
+# See https://github.com/elm-tooling/elm-language-server#server-settings
+runtime = "node"
+elmPath = "elm"
+elmFormatPath = "elm-format"
+elmTestPath = "elm-test"
+
+[language_server.elvish]
+filetypes = ["elvish"]
+roots = [".git", ".hg"]
+command = "elvish"
+args = ["-lsp"]
+
+[language_server.erlang-ls]
+filetypes = ["erlang"]
+# See https://github.com/erlang-ls/erlang_ls.git for more information and
+# how to configure. This default config should work in most cases though.
+roots = ["rebar.config", "erlang.mk", ".git", ".hg"]
+command = "erlang_ls"
+
+[language_server.gopls]
+filetypes = ["go"]
+roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
+command = "gopls"
+[language_server.gopls.settings.gopls]
+# See https://github.com/golang/tools/blob/master/gopls/doc/settings.md
+# "build.buildFlags" = []
+
+[language_server.haskell-language-server]
+filetypes = ["haskell"]
+roots = ["hie.yaml", "cabal.project", "Setup.hs", "stack.yaml", "*.cabal"]
+command = "haskell-language-server-wrapper"
+args = ["--lsp"]
+settings_section = "_"
+[language_server.haskell-language-server.settings._]
+# See https://haskell-language-server.readthedocs.io/en/latest/configuration.html
+# haskell.formattingProvider = "ormolu"
+
+[language_server.html-language-server]
+filetypes = ["html"]
+roots = ["package.json"]
+command = "vscode-html-languageserver"
 args = ["--stdio"]
 settings_section = "_"
-[language.javascriptreact.settings._]
+[language_server.html-language-server.settings._]
 # quotePreference = "single"
 # javascript.format.semicolons = "insert"
 
-[language.json]
+[language_server.intelephense]
+filetypes = ["php"]
+roots = [".htaccess", "composer.json"]
+command = "intelephense"
+args = ["--stdio"]
+settings_section = "intelephense"
+[language_server.intelephense.settings.intelephense]
+storagePath = "/tmp/intelephense"
+
+[language_server.json-language-server]
 filetypes = ["json"]
 roots = ["package.json"]
 command = "vscode-json-languageserver"
@@ -175,7 +198,7 @@ args = ["--stdio"]
 # Requires Julia package "LanguageServer"
 # Run: `julia --project=@kak-lsp -e 'import Pkg; Pkg.add("LanguageServer")'` to install it
 # Configuration adapted from https://github.com/neovim/nvim-lspconfig/blob/bcebfac7429cd8234960197dca8de1767f3ef5d3/lua/lspconfig/julials.lua
-[language.julia]
+[language_server.julia-language-server]
 filetypes = ["julia"]
 roots = ["Project.toml", ".git", ".hg"]
 command = "julia"
@@ -210,7 +233,7 @@ args = [
     run(server);
     """,
 ]
-[language.julia.settings]
+[language_server.julia-language-server.settings]
 # See https://github.com/julia-vscode/LanguageServer.jl/blob/master/src/requests/workspace.jl
 # Format options. See https://github.com/julia-vscode/DocumentFormat.jl/blob/master/src/DocumentFormat.jl
 # "julia.format.indent" = 4
@@ -219,12 +242,125 @@ args = [
 # Other options, see https://github.com/julia-vscode/LanguageServer.jl/blob/master/src/requests/workspace.jl
 # "julia.lint.run" = "true"
 
-[language.latex]
+[language_server.lua-language-server]
+filetypes = ["lua"]
+roots = [".git", ".hg"]
+command = "lua-language-server"
+settings_section = "Lua"
+[language_server.lua-language-server.settings.Lua]
+# See https://github.com/sumneko/vscode-lua/blob/master/setting/schema.json
+# diagnostics.enable = true
+
+[language_server.nimlsp]
+filetypes = ["nim"]
+roots = ["*.nimble", ".git", ".hg"]
+command = "nimlsp"
+
+[language_server.ocamllsp]
+filetypes = ["ocaml"]
+# Often useful to simply do a `touch dune-workspace` in your project root folder if you have problems with root detection
+roots = ["dune-workspace", "dune-project", "Makefile", "opam", "*.opam", "esy.json", ".git", ".hg", "dune"]
+command = "ocamllsp"
+
+[language_server.pls]
+filetypes = ["protobuf"]
+roots = [".git", ".hg"]
+command = "pls" # https://github.com/lasorda/protobuf-language-server
+
+[language_server.pylsp]
+filetypes = ["python"]
+roots = ["requirements.txt", "setup.py", ".git", ".hg"]
+command = "pylsp"
+settings_section = "_"
+[language_server.pylsp.settings._]
+# See https://github.com/python-lsp/python-lsp-server#configuration
+# pylsp.configurationSources = ["flake8"]
+pylsp.plugins.jedi_completion.include_params = true
+
+[language_server.r-language-server]
+filetypes = ["r"]
+roots = ["DESCRIPTION", ".git", ".hg"]
+command = "R"
+args = ["--slave", "-e", "languageserver::run()"]
+
+[language_server.racket-language-server]
+filetypes = ["racket"]
+roots = ["info.rkt"]
+command = "racket"
+args = ["-l", "racket-langserver"]
+
+[language_server.reason-ocamllsp]
+filetypes = ["reason"]
+roots = ["package.json", "Makefile", ".git", ".hg"]
+command = "ocamllsp"
+
+# [language_server.rls]
+# filetypes = ["rust"]
+# roots = ["Cargo.toml"]
+# command = "sh"
+# args = [
+#     "-c",
+#     """
+#         if path=$(rustup which rls 2>/dev/null); then
+#             "$path"
+#         else
+#             rls
+#         fi
+#     """,
+# ]
+# settings_section = "rust"
+# [language_server.rls.settings.rust]
+# # See https://github.com/rust-lang/rls#configuration
+# # features = []
+
+[language_server.rnix-lsp]
+filetypes = ["nix"]
+roots = ["flake.nix", "shell.nix", ".git", ".hg"]
+command = "rnix-lsp"
+
+[language_server.rust-analyzer]
+filetypes = ["rust"]
+roots = ["Cargo.toml"]
+command = "sh"
+args = [
+    "-c",
+    """
+        if path=$(rustup which rust-analyzer 2>/dev/null); then
+            "$path"
+        else
+            rust-analyzer
+        fi
+    """,
+]
+[language_server.rust-analyzer.settings.rust-analyzer]
+# See https://rust-analyzer.github.io/manual.html#configuration
+hoverActions.enable = false # kak-lsp doesn't support this at the moment
+# cargo.features = []
+
+[language_server.solargraph]
+filetypes = ["ruby"]
+roots = ["Gemfile"]
+command = "solargraph"
+args = ["stdio"]
+settings_section = "_"
+[language_server.solargraph.settings._]
+# See https://github.com/castwide/solargraph/blob/master/lib/solargraph/language_server/host.rb
+# diagnostics = false
+
+[language_server.terraform-ls]
+filetypes = ["terraform"]
+roots = ["*.tf"]
+command = "terraform-ls"
+args = ["serve"]
+[language_server.terraform-ls.settings.terraform-ls]
+# See https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md
+# rootModulePaths = []
+
+[language_server.texlab]
 filetypes = ["latex"]
 roots = [".git", ".hg"]
 command = "texlab"
-settings_section = "texlab"
-[language.latex.settings.texlab]
+[language_server.texlab.settings.texlab]
 # See https://github.com/latex-lsp/texlab/wiki/Configuration
 #
 # Preview configuration for zathura with SyncTeX search.
@@ -248,158 +384,28 @@ forwardSearch.args = [
     """,
 ]
 
-[language.lua]
-filetypes = ["lua"]
-roots = [".git", ".hg"]
-command = "lua-language-server"
-[language.lua.settings.Lua]
-# See https://github.com/sumneko/vscode-lua/blob/master/setting/schema.json
-# diagnostics.enable = true
-
-[language.nim]
-filetypes = ["nim"]
-roots = ["*.nimble", ".git", ".hg"]
-command = "nimlsp"
-
-[language.nix]
-filetypes = ["nix"]
-roots = ["flake.nix", "shell.nix", ".git", ".hg"]
-command = "rnix-lsp"
-
-[language.ocaml]
-filetypes = ["ocaml"]
-# Often useful to simply do a `touch dune-workspace` in your project root folder if you have problems with root detection
-roots = ["dune-workspace", "dune-project", "Makefile", "opam", "*.opam", "esy.json", ".git", ".hg", "dune"]
-command = "ocamllsp"
-
-[language.php]
-filetypes = ["php"]
-roots = [".htaccess", "composer.json"]
-command = "intelephense"
-args = ["--stdio"]
-settings_section = "intelephense"
-[language.php.settings]
-intelephense.storagePath = "/tmp/intelephense"
-
-[language.proto]
-filetypes = ["protobuf"]
-roots = [".git", ".hg"]
-command = "pls" # https://github.com/lasorda/protobuf-language-server
-
-[language.python]
-filetypes = ["python"]
-roots = ["requirements.txt", "setup.py", ".git", ".hg"]
-command = "pylsp"
-settings_section = "_"
-[language.python.settings._]
-# See https://github.com/python-lsp/python-lsp-server#configuration
-# pylsp.configurationSources = ["flake8"]
-pylsp.plugins.jedi_completion.include_params = true
-
-[language.r]
-filetypes = ["r"]
-roots = ["DESCRIPTION", ".git", ".hg"]
-command = "R"
-args = ["--slave", "-e", "languageserver::run()"]
-
-[language.racket]
-filetypes = ["racket"]
-roots = ["info.rkt"]
-command = "racket"
-args = ["-l", "racket-langserver"]
-
-[language.reason]
-filetypes = ["reason"]
-roots = ["package.json", "Makefile", ".git", ".hg"]
-command = "ocamllsp"
-
-[language.ruby]
-filetypes = ["ruby"]
-roots = ["Gemfile"]
-command = "solargraph"
-args = ["stdio"]
-settings_section = "_"
-[language.ruby.settings._]
-# See https://github.com/castwide/solargraph/blob/master/lib/solargraph/language_server/host.rb
-# diagnostics = false
-
-# [language.rust]
-# filetypes = ["rust"]
-# roots = ["Cargo.toml"]
-# command = "sh"
-# args = [
-#     "-c",
-#     """
-#         if path=$(rustup which rls 2>/dev/null); then
-#             "$path"
-#         else
-#             rls
-#         fi
-#     """,
-# ]
-# [language.rust.settings.rust]
-# # See https://github.com/rust-lang/rls#configuration
-# # features = []
-
-[language.rust]
-filetypes = ["rust"]
-roots = ["Cargo.toml"]
-command = "sh"
-args = [
-    "-c",
-    """
-        if path=$(rustup which rust-analyzer 2>/dev/null); then
-            "$path"
-        else
-            rust-analyzer
-        fi
-    """,
-]
-settings_section = "rust-analyzer"
-[language.rust.settings.rust-analyzer]
-# See https://rust-analyzer.github.io/manual.html#configuration
-hoverActions.enable = false # kak-lsp doesn't support this at the moment
-# cargo.features = []
-
-[language.terraform]
-filetypes = ["terraform"]
-roots = ["*.tf"]
-command = "terraform-ls"
-args = ["serve"]
-[language.terraform.settings.terraform-ls]
-# See https://github.com/hashicorp/terraform-ls/blob/main/docs/SETTINGS.md
-# rootModulePaths = []
-
-[language.typescriptreact]
-filetypes = ["typescript"]
-roots = ["package.json", "tsconfig.json", ".git", ".hg"]
+[language_server.typescript-language-server]
+filetypes = ["javascript", "typescript"]
+roots = ["package.json", "tsconfig.json", "jsconfig.json", ".git", ".hg"]
 command = "typescript-language-server"
 args = ["--stdio"]
 settings_section = "_"
-[language.typescriptreact.settings._]
+[language_server.typescript-language-server.settings._]
 # quotePreference = "double"
 # typescript.format.semicolons = "insert"
 
-# [language.typescript]
-# filetypes = ["typescript"]
-# roots = ["package.json", "tsconfig.json", ".git", ".hg"]
-# command = "deno"
-# args = ["lsp"]
-# [language.typescript.settings.deno]
-# enable = true
-# lint = true
-
-[language.yaml]
+[language_server.yaml-language-server]
 filetypes = ["yaml"]
 roots = [".git", ".hg"]
 command = "yaml-language-server"
 args = ["--stdio"]
-[language.yaml.settings]
+settings_section = "yaml"
+[language_server.yaml-language-server.settings.yaml]
 # See https://github.com/redhat-developer/yaml-language-server#language-server-settings
 # Defaults are at https://github.com/redhat-developer/yaml-language-server/blob/master/src/yamlSettings.ts
-# yaml.format.enable = true
+# format.enable = true
 
-[language.zig]
+[language_server.zls]
 filetypes = ["zig"]
 roots = ["build.zig"]
 command = "zls"

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1184,17 +1184,17 @@ $([ -z ${kak_hook_param+x} ] || echo hook = true)
 " | eval "${kak_opt_lsp_cmd} --request") > /dev/null 2>&1 < /dev/null & }
 }
 
-define-command lsp-formatting -docstring "Format document" %{
-    lsp-formatting-request false
+define-command lsp-formatting -params 0..1 -docstring "lsp-formatting [<server_name>]: format document" %{
+    lsp-formatting-request false %arg{1}
 }
 
-define-command lsp-formatting-sync -docstring "Format document, blocking Kakoune session until done" %{
+define-command lsp-formatting-sync -params 0..1 -docstring "lsp-formatting-sync [<server_name>]: format document, blocking Kakoune session until done" %{
     lsp-require-enabled lsp-formatting-sync
     lsp-did-change-sync
-    lsp-formatting-request true
+    lsp-formatting-request true %arg{1}
 }
 
-define-command -hidden lsp-formatting-request -params 1 %{ evaluate-commands -no-hooks %sh{
+define-command -hidden lsp-formatting-request -params 1..2 %{ evaluate-commands -no-hooks %sh{
     sync=$1
     fifo=""
     if "$sync"; then
@@ -1214,6 +1214,7 @@ filetype = \"${kak_opt_filetype}\"
 version  = ${kak_timestamp:-0}
 ${fifo}
 method   = \"textDocument/formatting\"
+$([ -z ${2} ] || echo server = \"${2}\")
 $([ -z ${kak_hook_param+x} ] || echo hook = true)
 [params]
 tabSize      = ${kak_opt_tabstop}
@@ -1226,17 +1227,17 @@ insertSpaces = ${kak_opt_lsp_insert_spaces}
     fi
 }}
 
-define-command lsp-range-formatting -docstring "Format selections" %{
-    lsp-range-formatting-request false
+define-command lsp-range-formatting -params 0..1 -docstring "lsp-range-formatting [<server_name>]: format selections" %{
+    lsp-range-formatting-request false %arg{1}
 }
 
-define-command lsp-range-formatting-sync -docstring "Format selections, blocking Kakoune session until done" %{
+define-command lsp-range-formatting-sync -params 0..1 -docstring "lsp-range-formatting-sync [<server_name>]: format selections, blocking Kakoune session until done" %{
     lsp-require-enabled lsp-range-formatting-sync
     lsp-did-change-sync
-    lsp-range-formatting-request true
+    lsp-range-formatting-request true %arg{1}
 }
 
-define-command -hidden lsp-range-formatting-request -params 1 %{ evaluate-commands -no-hooks %sh{
+define-command -hidden lsp-range-formatting-request -params 1..2 %{ evaluate-commands -no-hooks %sh{
     sync=$1
     fifo=""
     if "$sync"; then
@@ -1273,6 +1274,7 @@ buffile  = \"${kak_buffile}\"
 filetype = \"${kak_opt_filetype}\"
 version  = ${kak_timestamp:-0}
 method   = \"textDocument/rangeFormatting\"
+$([ -z ${2} ] || echo server = \"${2}\")
 $([ -z ${kak_hook_param+x} ] || echo hook = true)
 ${fifo}
 [params]
@@ -1736,41 +1738,41 @@ define-command -hidden lsp-show-signature-help -params 2 -docstring "Render sign
     info -markup -anchor %arg{1} -style above -- %arg{2}
 }
 
-define-command -hidden lsp-show-message-error -params 1 -docstring %{
+define-command -hidden lsp-show-message-error -params 2 -docstring %{
     lsp-show-message-error <message>
     Render language server message of the "error" level.
 } %{
-    echo -debug "kak-lsp: error from server:" %arg{1}
+    echo -debug "kak-lsp: error from server %arg{1}: %arg{2}"
     evaluate-commands -try-client %opt{toolsclient} %{
-        info "kak-lsp: error from server: %arg{1}"
+        info "kak-lsp: error from server %arg{1}: %arg{2}"
     }
 }
 
-define-command -hidden lsp-show-message-warning -params 1 -docstring %{
+define-command -hidden lsp-show-message-warning -params 2 -docstring %{
     lsp-show-message-warning <message>
     Render language server message of the "warning" level.
 } %{
-    echo -debug "kak-lsp: warning from server:" %arg{1}
+    echo -debug "kak-lsp: warning from server %arg{1}: %arg{2}"
     evaluate-commands -try-client %opt{toolsclient} %{
-        echo "kak-lsp: warning from server:" %arg{1}
+        echo "kak-lsp: warning from server %arg{1}: %arg{2}"
     }
 }
 
-define-command -hidden lsp-show-message-info -params 1 -docstring %{
+define-command -hidden lsp-show-message-info -params 2 -docstring %{
     lsp-show-message-info <message>
     Render language server message of the "info" level.
 } %{
-    echo -debug "kak-lsp: info from server:" %arg{1}
+    echo -debug "kak-lsp: info from server %arg{1}: %arg{2}"
     evaluate-commands -try-client %opt{toolsclient} %{
-        echo "kak-lsp: info from server:" %arg{1}
+        echo "kak-lsp: info from server %arg{1}: %arg{2}"
     }
 }
 
-define-command -hidden lsp-show-message-log -params 1 -docstring %{
+define-command -hidden lsp-show-message-log -params 2 -docstring %{
     lsp-show-message-log <message>
     Render language server message of the "log" level.
 } %{
-    echo -debug "kak-lsp: log:" %arg{1}
+    echo -debug "kak-lsp: [%arg{1}] log %arg{1}: %arg{2}"
 }
 
 define-command -hidden lsp-show-message-request -params 4.. -docstring %{

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -8,11 +8,13 @@ use itertools::Itertools;
 use lsp_types::notification::*;
 use lsp_types::request::*;
 use lsp_types::*;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::process;
 use url::Url;
 
-pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
+pub fn initialize(meta: EditorMeta, ctx: &mut Context) {
     let initialization_options = request_initialization_options_from_kakoune(&meta, ctx);
     let symbol_kind_capability = Some(SymbolKindCapability {
         value_set: Some(vec![
@@ -45,349 +47,398 @@ pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
         ]),
     });
     #[allow(deprecated)] // for root_path
-    let params = InitializeParams {
-        capabilities: ClientCapabilities {
-            workspace: Some(WorkspaceClientCapabilities {
-                apply_edit: Some(true),
-                workspace_edit: Some(WorkspaceEditClientCapabilities {
-                    document_changes: Some(true),
-                    resource_operations: Some(vec![
-                        ResourceOperationKind::Create,
-                        ResourceOperationKind::Delete,
-                        ResourceOperationKind::Rename,
-                    ]),
-                    failure_handling: Some(FailureHandlingKind::Abort),
-                    normalizes_line_endings: Some(false),
-                    change_annotation_support: Some(
-                        ChangeAnnotationWorkspaceEditClientCapabilities {
-                            groups_on_label: None,
-                        },
-                    ),
-                }),
-                did_change_configuration: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
-                    dynamic_registration: Some(true),
-                    relative_pattern_support: Some(true),
-                }),
-                symbol: Some(WorkspaceSymbolClientCapabilities {
-                    dynamic_registration: Some(false),
-                    symbol_kind: symbol_kind_capability.clone(),
-                    tag_support: None,
-                    resolve_support: None,
-                }),
-                execute_command: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                workspace_folders: Some(true),
-                configuration: Some(true),
-                semantic_tokens: None,
-                code_lens: Some(CodeLensWorkspaceClientCapabilities {
-                    refresh_support: None,
-                }),
-                file_operations: None,
-                inline_value: None,
-                inlay_hint: Some(InlayHintWorkspaceClientCapabilities {
-                    refresh_support: Some(false),
-                }),
-                diagnostic: None,
-            }),
-            text_document: Some(TextDocumentClientCapabilities {
-                synchronization: Some(TextDocumentSyncClientCapabilities {
-                    dynamic_registration: Some(false),
-                    will_save: Some(false),
-                    will_save_wait_until: Some(false),
-                    did_save: Some(true),
-                }),
-                completion: Some(CompletionClientCapabilities {
-                    dynamic_registration: Some(false),
-                    completion_item: Some(CompletionItemCapability {
-                        snippet_support: Some(ctx.config.snippet_support),
-                        commit_characters_support: Some(false),
-                        documentation_format: Some(vec![
-                            MarkupKind::Markdown,
-                            MarkupKind::PlainText,
-                        ]),
-                        deprecated_support: Some(false),
-                        preselect_support: Some(false),
-                        tag_support: None,
-                        insert_replace_support: None,
-                        resolve_support: Some(CompletionItemCapabilityResolveSupport {
-                            properties: vec![
-                                "additionalTextEdits".to_string(),
-                                "detail".to_string(),
-                                "documentation".to_string(),
-                            ],
-                        }),
-                        insert_text_mode_support: None,
-                        label_details_support: None,
-                    }),
-                    completion_item_kind: Some(CompletionItemKindCapability {
-                        value_set: Some(vec![
-                            CompletionItemKind::TEXT,
-                            CompletionItemKind::METHOD,
-                            CompletionItemKind::FUNCTION,
-                            CompletionItemKind::CONSTRUCTOR,
-                            CompletionItemKind::FIELD,
-                            CompletionItemKind::VARIABLE,
-                            CompletionItemKind::CLASS,
-                            CompletionItemKind::INTERFACE,
-                            CompletionItemKind::MODULE,
-                            CompletionItemKind::PROPERTY,
-                            CompletionItemKind::UNIT,
-                            CompletionItemKind::VALUE,
-                            CompletionItemKind::ENUM,
-                            CompletionItemKind::KEYWORD,
-                            CompletionItemKind::SNIPPET,
-                            CompletionItemKind::COLOR,
-                            CompletionItemKind::FILE,
-                            CompletionItemKind::REFERENCE,
-                            CompletionItemKind::FOLDER,
-                            CompletionItemKind::ENUM_MEMBER,
-                            CompletionItemKind::CONSTANT,
-                            CompletionItemKind::STRUCT,
-                            CompletionItemKind::EVENT,
-                            CompletionItemKind::OPERATOR,
-                            CompletionItemKind::TYPE_PARAMETER,
-                        ]),
-                    }),
-                    context_support: Some(false),
-                    insert_text_mode: None,
-                    completion_list: None,
-                }),
-                hover: Some(HoverClientCapabilities {
-                    dynamic_registration: Some(false),
-                    content_format: Some(vec![MarkupKind::Markdown, MarkupKind::PlainText]),
-                }),
-                signature_help: Some(SignatureHelpClientCapabilities {
-                    dynamic_registration: Some(false),
-                    signature_information: Some(SignatureInformationSettings {
-                        documentation_format: Some(vec![MarkupKind::PlainText]),
-                        parameter_information: Some(ParameterInformationSettings {
-                            label_offset_support: Some(false),
-                        }),
-                        active_parameter_support: None,
-                    }),
-                    context_support: Some(false),
-                }),
-                references: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                document_highlight: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                document_symbol: Some(DocumentSymbolClientCapabilities {
-                    dynamic_registration: Some(false),
-                    symbol_kind: symbol_kind_capability,
-                    hierarchical_document_symbol_support: Some(true),
-                    tag_support: None,
-                }),
-                formatting: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                range_formatting: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                on_type_formatting: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                declaration: Some(GotoCapability {
-                    dynamic_registration: Some(false),
-                    link_support: Some(false),
-                }),
-                definition: Some(GotoCapability {
-                    dynamic_registration: Some(false),
-                    link_support: Some(false),
-                }),
-                type_definition: Some(GotoCapability {
-                    dynamic_registration: Some(false),
-                    link_support: Some(false),
-                }),
-                implementation: Some(GotoCapability {
-                    dynamic_registration: Some(false),
-                    link_support: Some(false),
-                }),
-                code_action: Some(CodeActionClientCapabilities {
-                    dynamic_registration: Some(false),
-                    code_action_literal_support: Some(CodeActionLiteralSupport {
-                        code_action_kind: CodeActionKindLiteralSupport {
-                            value_set: [
-                                "quickfix",
-                                "refactor",
-                                "refactor.extract",
-                                "refactor.inline",
-                                "refactor.rewrite",
-                                "source",
-                                "source.organizeImports",
-                            ]
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect(),
-                        },
-                    }),
-                    is_preferred_support: Some(false),
-                    disabled_support: None,
-                    data_support: None,
-                    resolve_support: Some(CodeActionCapabilityResolveSupport {
-                        properties: ["edit"].iter().map(|s| s.to_string()).collect(),
-                    }),
-                    honors_change_annotations: None,
-                }),
-                code_lens: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                document_link: Some(DocumentLinkClientCapabilities {
-                    dynamic_registration: Some(false),
-                    tooltip_support: Some(false),
-                }),
-                color_provider: Some(DynamicRegistrationClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                rename: Some(RenameClientCapabilities {
-                    dynamic_registration: Some(false),
-                    prepare_support: Some(false),
-                    prepare_support_default_behavior: None,
-                    honors_change_annotations: None,
-                }),
-                publish_diagnostics: Some(PublishDiagnosticsClientCapabilities {
-                    related_information: Some(true),
-                    tag_support: None,
-                    version_support: None,
-                    code_description_support: None,
-                    data_support: None,
-                }),
-                folding_range: None,
-                selection_range: Some(SelectionRangeClientCapabilities {
-                    dynamic_registration: None,
-                }),
-                semantic_tokens: Some(SemanticTokensClientCapabilities {
-                    dynamic_registration: Some(false),
-                    requests: SemanticTokensClientCapabilitiesRequests {
-                        range: Some(false),
-                        full: Some(SemanticTokensFullOptions::Bool(true)),
+    let req_params = ctx
+        .language_servers
+        .iter()
+        .enumerate()
+        .map(
+            |(
+                idx,
+                (
+                    server_name,
+                    ServerSettings {
+                        root_path,
+                        preferred_offset_encoding,
+                        ..
                     },
-                    token_types: ctx
-                        .config
-                        .semantic_tokens
-                        .faces
-                        .iter()
-                        .map(|token_config| token_config.token.clone().into())
-                        // Collect into set first to remove duplicates
-                        .collect::<HashSet<SemanticTokenType>>()
-                        .into_iter()
-                        .collect(),
-                    token_modifiers: ctx
-                        .config
-                        .semantic_tokens
-                        .faces
-                        .iter()
-                        // Get all modifiers used in token definitions
-                        .flat_map(|token_config| token_config.modifiers.clone())
-                        // Collect into set first to remove duplicates
-                        .collect::<HashSet<SemanticTokenModifier>>()
-                        .into_iter()
-                        .collect(),
-                    formats: vec![TokenFormat::RELATIVE],
-                    overlapping_token_support: None,
-                    multiline_token_support: None,
-                    augments_syntax_tokens: None,
-                    server_cancel_support: Some(true),
-                }),
-                linked_editing_range: None,
-                call_hierarchy: Some(CallHierarchyClientCapabilities {
-                    dynamic_registration: Some(false),
-                }),
-                moniker: None,
-                inline_value: None,
-                type_hierarchy: None,
-                inlay_hint: Some(InlayHintClientCapabilities {
-                    dynamic_registration: Some(false),
-                    resolve_support: None,
-                }),
-                diagnostic: None,
-            }),
-            window: Some(WindowClientCapabilities {
-                work_done_progress: Some(true),
-                show_message: Some(ShowMessageRequestClientCapabilities {
-                    message_action_item: Some(MessageActionItemCapabilities {
-                        additional_properties_support: Some(true),
-                    }),
-                }),
-                show_document: None,
-            }),
-            general: Some(GeneralClientCapabilities {
-                regular_expressions: Some(RegularExpressionsClientCapabilities {
-                    engine: "Rust regex".to_string(),
-                    version: None,
-                }),
-                markdown: Some(MarkdownClientCapabilities {
-                    parser: "kak-lsp".to_string(),
-                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
-                    allowed_tags: None,
-                }),
-                stale_request_support: None,
-                position_encodings: Some(match ctx.preferred_offset_encoding {
-                    None | Some(OffsetEncoding::Utf8) => {
-                        vec![PositionEncodingKind::UTF8, PositionEncodingKind::UTF16]
-                    }
-                    Some(OffsetEncoding::Utf16) => {
-                        vec![PositionEncodingKind::UTF16, PositionEncodingKind::UTF8]
-                    }
-                }),
-            }),
-            offset_encoding: Some(
-                match ctx.preferred_offset_encoding {
-                    None | Some(OffsetEncoding::Utf8) => ["utf-8", "utf-16"],
-                    Some(OffsetEncoding::Utf16) => ["utf-16", "utf-8"],
-                }
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
-            ),
-            experimental: None,
-        },
-        initialization_options,
-        process_id: Some(process::id()),
-        root_uri: Some(Url::from_file_path(root_path).unwrap()),
-        root_path: Some(root_path.to_string()),
-        trace: Some(TraceValue::Off),
-        workspace_folders: Some(vec![WorkspaceFolder {
-            uri: Url::from_file_path(root_path).unwrap(),
-            name: root_path.to_string(),
-        }]),
-        client_info: Some(ClientInfo {
-            name: env!("CARGO_PKG_NAME").to_string(),
-            version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        }),
-        locale: None,
-    };
+                ),
+            )| {
+                (
+                    server_name.clone(),
+                    vec![InitializeParams {
+                        capabilities: ClientCapabilities {
+                            workspace: Some(WorkspaceClientCapabilities {
+                                apply_edit: Some(true),
+                                workspace_edit: Some(WorkspaceEditClientCapabilities {
+                                    document_changes: Some(true),
+                                    resource_operations: Some(vec![
+                                        ResourceOperationKind::Create,
+                                        ResourceOperationKind::Delete,
+                                        ResourceOperationKind::Rename,
+                                    ]),
+                                    failure_handling: Some(FailureHandlingKind::Abort),
+                                    normalizes_line_endings: Some(false),
+                                    change_annotation_support: Some(
+                                        ChangeAnnotationWorkspaceEditClientCapabilities {
+                                            groups_on_label: None,
+                                        },
+                                    ),
+                                }),
+                                did_change_configuration: Some(
+                                    DynamicRegistrationClientCapabilities {
+                                        dynamic_registration: Some(false),
+                                    },
+                                ),
+                                did_change_watched_files: Some(
+                                    DidChangeWatchedFilesClientCapabilities {
+                                        dynamic_registration: Some(true),
+                                        relative_pattern_support: Some(true),
+                                    },
+                                ),
+                                symbol: Some(WorkspaceSymbolClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    symbol_kind: symbol_kind_capability.clone(),
+                                    tag_support: None,
+                                    resolve_support: None,
+                                }),
+                                execute_command: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                workspace_folders: Some(true),
+                                configuration: Some(true),
+                                semantic_tokens: None,
+                                code_lens: Some(CodeLensWorkspaceClientCapabilities {
+                                    refresh_support: None,
+                                }),
+                                file_operations: None,
+                                inline_value: None,
+                                inlay_hint: Some(InlayHintWorkspaceClientCapabilities {
+                                    refresh_support: Some(false),
+                                }),
+                                diagnostic: None,
+                            }),
+                            text_document: Some(TextDocumentClientCapabilities {
+                                synchronization: Some(TextDocumentSyncClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    will_save: Some(false),
+                                    will_save_wait_until: Some(false),
+                                    did_save: Some(true),
+                                }),
+                                completion: Some(CompletionClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    completion_item: Some(CompletionItemCapability {
+                                        snippet_support: Some(ctx.config.snippet_support),
+                                        commit_characters_support: Some(false),
+                                        documentation_format: Some(vec![
+                                            MarkupKind::Markdown,
+                                            MarkupKind::PlainText,
+                                        ]),
+                                        deprecated_support: Some(false),
+                                        preselect_support: Some(false),
+                                        tag_support: None,
+                                        insert_replace_support: None,
+                                        resolve_support: Some(
+                                            CompletionItemCapabilityResolveSupport {
+                                                properties: vec![
+                                                    "additionalTextEdits".to_string(),
+                                                    "detail".to_string(),
+                                                    "documentation".to_string(),
+                                                ],
+                                            },
+                                        ),
+                                        insert_text_mode_support: None,
+                                        label_details_support: None,
+                                    }),
+                                    completion_item_kind: Some(CompletionItemKindCapability {
+                                        value_set: Some(vec![
+                                            CompletionItemKind::TEXT,
+                                            CompletionItemKind::METHOD,
+                                            CompletionItemKind::FUNCTION,
+                                            CompletionItemKind::CONSTRUCTOR,
+                                            CompletionItemKind::FIELD,
+                                            CompletionItemKind::VARIABLE,
+                                            CompletionItemKind::CLASS,
+                                            CompletionItemKind::INTERFACE,
+                                            CompletionItemKind::MODULE,
+                                            CompletionItemKind::PROPERTY,
+                                            CompletionItemKind::UNIT,
+                                            CompletionItemKind::VALUE,
+                                            CompletionItemKind::ENUM,
+                                            CompletionItemKind::KEYWORD,
+                                            CompletionItemKind::SNIPPET,
+                                            CompletionItemKind::COLOR,
+                                            CompletionItemKind::FILE,
+                                            CompletionItemKind::REFERENCE,
+                                            CompletionItemKind::FOLDER,
+                                            CompletionItemKind::ENUM_MEMBER,
+                                            CompletionItemKind::CONSTANT,
+                                            CompletionItemKind::STRUCT,
+                                            CompletionItemKind::EVENT,
+                                            CompletionItemKind::OPERATOR,
+                                            CompletionItemKind::TYPE_PARAMETER,
+                                        ]),
+                                    }),
+                                    context_support: Some(false),
+                                    insert_text_mode: None,
+                                    completion_list: None,
+                                }),
+                                hover: Some(HoverClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    content_format: Some(vec![
+                                        MarkupKind::Markdown,
+                                        MarkupKind::PlainText,
+                                    ]),
+                                }),
+                                signature_help: Some(SignatureHelpClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    signature_information: Some(SignatureInformationSettings {
+                                        documentation_format: Some(vec![MarkupKind::PlainText]),
+                                        parameter_information: Some(ParameterInformationSettings {
+                                            label_offset_support: Some(false),
+                                        }),
+                                        active_parameter_support: None,
+                                    }),
+                                    context_support: Some(false),
+                                }),
+                                references: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                document_highlight: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                document_symbol: Some(DocumentSymbolClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    symbol_kind: symbol_kind_capability.clone(),
+                                    hierarchical_document_symbol_support: Some(true),
+                                    tag_support: None,
+                                }),
+                                formatting: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                range_formatting: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                on_type_formatting: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                declaration: Some(GotoCapability {
+                                    dynamic_registration: Some(false),
+                                    link_support: Some(false),
+                                }),
+                                definition: Some(GotoCapability {
+                                    dynamic_registration: Some(false),
+                                    link_support: Some(false),
+                                }),
+                                type_definition: Some(GotoCapability {
+                                    dynamic_registration: Some(false),
+                                    link_support: Some(false),
+                                }),
+                                implementation: Some(GotoCapability {
+                                    dynamic_registration: Some(false),
+                                    link_support: Some(false),
+                                }),
+                                code_action: Some(CodeActionClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    code_action_literal_support: Some(CodeActionLiteralSupport {
+                                        code_action_kind: CodeActionKindLiteralSupport {
+                                            value_set: [
+                                                "quickfix",
+                                                "refactor",
+                                                "refactor.extract",
+                                                "refactor.inline",
+                                                "refactor.rewrite",
+                                                "source",
+                                                "source.organizeImports",
+                                            ]
+                                            .iter()
+                                            .map(|s| s.to_string())
+                                            .collect(),
+                                        },
+                                    }),
+                                    is_preferred_support: Some(false),
+                                    disabled_support: None,
+                                    data_support: None,
+                                    resolve_support: Some(CodeActionCapabilityResolveSupport {
+                                        properties: ["edit"]
+                                            .iter()
+                                            .map(|s| s.to_string())
+                                            .collect(),
+                                    }),
+                                    honors_change_annotations: None,
+                                }),
+                                code_lens: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                document_link: Some(DocumentLinkClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    tooltip_support: Some(false),
+                                }),
+                                color_provider: Some(DynamicRegistrationClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                rename: Some(RenameClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    prepare_support: Some(false),
+                                    prepare_support_default_behavior: None,
+                                    honors_change_annotations: None,
+                                }),
+                                publish_diagnostics: Some(PublishDiagnosticsClientCapabilities {
+                                    related_information: Some(true),
+                                    tag_support: None,
+                                    version_support: None,
+                                    code_description_support: None,
+                                    data_support: None,
+                                }),
+                                folding_range: None,
+                                selection_range: Some(SelectionRangeClientCapabilities {
+                                    dynamic_registration: None,
+                                }),
+                                semantic_tokens: Some(SemanticTokensClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    requests: SemanticTokensClientCapabilitiesRequests {
+                                        range: Some(false),
+                                        full: Some(SemanticTokensFullOptions::Bool(true)),
+                                    },
+                                    token_types: ctx
+                                        .config
+                                        .semantic_tokens
+                                        .faces
+                                        .iter()
+                                        .map(|token_config| token_config.token.clone().into())
+                                        // Collect into set first to remove duplicates
+                                        .collect::<HashSet<SemanticTokenType>>()
+                                        .into_iter()
+                                        .collect(),
+                                    token_modifiers: ctx
+                                        .config
+                                        .semantic_tokens
+                                        .faces
+                                        .iter()
+                                        // Get all modifiers used in token definitions
+                                        .flat_map(|token_config| token_config.modifiers.clone())
+                                        // Collect into set first to remove duplicates
+                                        .collect::<HashSet<SemanticTokenModifier>>()
+                                        .into_iter()
+                                        .collect(),
+                                    formats: vec![TokenFormat::RELATIVE],
+                                    overlapping_token_support: None,
+                                    multiline_token_support: None,
+                                    augments_syntax_tokens: None,
+                                    server_cancel_support: Some(true),
+                                }),
+                                linked_editing_range: None,
+                                call_hierarchy: Some(CallHierarchyClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                }),
+                                moniker: None,
+                                inline_value: None,
+                                type_hierarchy: None,
+                                inlay_hint: Some(InlayHintClientCapabilities {
+                                    dynamic_registration: Some(false),
+                                    resolve_support: None,
+                                }),
+                                diagnostic: None,
+                            }),
+                            window: Some(WindowClientCapabilities {
+                                work_done_progress: Some(true),
+                                show_message: Some(ShowMessageRequestClientCapabilities {
+                                    message_action_item: Some(MessageActionItemCapabilities {
+                                        additional_properties_support: Some(true),
+                                    }),
+                                }),
+                                show_document: None,
+                            }),
+                            general: Some(GeneralClientCapabilities {
+                                regular_expressions: Some(RegularExpressionsClientCapabilities {
+                                    engine: "Rust regex".to_string(),
+                                    version: None,
+                                }),
+                                markdown: Some(MarkdownClientCapabilities {
+                                    parser: "kak-lsp".to_string(),
+                                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                                    allowed_tags: None,
+                                }),
+                                stale_request_support: None,
+                                position_encodings: Some(match preferred_offset_encoding {
+                                    None | Some(OffsetEncoding::Utf8) => {
+                                        vec![
+                                            PositionEncodingKind::UTF8,
+                                            PositionEncodingKind::UTF16,
+                                        ]
+                                    }
+                                    Some(OffsetEncoding::Utf16) => {
+                                        vec![
+                                            PositionEncodingKind::UTF16,
+                                            PositionEncodingKind::UTF8,
+                                        ]
+                                    }
+                                }),
+                            }),
+                            offset_encoding: Some(
+                                match preferred_offset_encoding {
+                                    None | Some(OffsetEncoding::Utf8) => ["utf-8", "utf-16"],
+                                    Some(OffsetEncoding::Utf16) => ["utf-16", "utf-8"],
+                                }
+                                .iter()
+                                .map(|s| s.to_string())
+                                .collect(),
+                            ),
+                            experimental: None,
+                        },
+                        initialization_options: initialization_options[idx].clone(),
+                        process_id: Some(process::id()),
+                        root_uri: Some(Url::from_file_path(root_path).unwrap()),
+                        root_path: Some(root_path.to_string()),
+                        trace: Some(TraceValue::Off),
+                        workspace_folders: Some(vec![WorkspaceFolder {
+                            uri: Url::from_file_path(root_path).unwrap(),
+                            name: root_path.to_string(),
+                        }]),
+                        client_info: Some(ClientInfo {
+                            name: env!("CARGO_PKG_NAME").to_string(),
+                            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                        }),
+                        locale: None,
+                    }],
+                )
+            },
+        )
+        .collect();
 
-    ctx.call::<Initialize, _>(meta, params, move |ctx: &mut Context, _meta, result| {
-        ctx.offset_encoding = result
-            .capabilities
-            .position_encoding
-            .as_ref()
-            .map(|enc| enc.as_str())
-            .or(result.offset_encoding.as_deref())
-            .map(|encoding| match encoding {
-                "utf-8" => OffsetEncoding::Utf8,
-                "utf-16" => OffsetEncoding::Utf16,
-                encoding => {
-                    error!("Language server sent unsupported offset encoding: {encoding}");
-                    OffsetEncoding::Utf16
+    ctx.call::<Initialize, _>(meta, RequestParams::Each(req_params) , move |ctx, _meta, results| {
+        let results: HashMap<_,_> = results.into_iter().collect();
+        let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+
+        for server_name in &servers {
+            let result = &results[server_name];
+            if let Some(server) = ctx.language_servers.get_mut(server_name) {
+                server.offset_encoding = result
+                    .capabilities
+                    .position_encoding
+                    .as_ref()
+                    .map(|enc| enc.as_str())
+                    .or(result.offset_encoding.as_deref())
+                    .map(|encoding| match encoding {
+                        "utf-8" => OffsetEncoding::Utf8,
+                        "utf-16" => OffsetEncoding::Utf16,
+                        encoding => {
+                            error!("Language server sent unsupported offset encoding: {encoding}");
+                            OffsetEncoding::Utf16
+                        }
+                    })
+                    .unwrap_or_default();
+                if matches!(
+                    (server.preferred_offset_encoding, server.offset_encoding),
+                    (Some(OffsetEncoding::Utf8), OffsetEncoding::Utf16)) {
+                        warn!(
+                            "Requested offset encoding utf-8 is not supported by {} server, falling back to utf-16",
+                            server_name,
+                        );
                 }
-            })
-            .unwrap_or(OffsetEncoding::Utf16);
-        if matches!(
-            (ctx.preferred_offset_encoding, ctx.offset_encoding),
-            (Some(OffsetEncoding::Utf8), OffsetEncoding::Utf16)) {
-                warn!(
-                    "Requested offset encoding utf-8 is not supported by server, falling back to utf-16"
-                );
+                server.capabilities = Some(result.capabilities.clone());
+                ctx.notify::<Initialized>(server_name, InitializedParams {});
+            }
         }
-        ctx.capabilities = Some(result.capabilities);
-        ctx.notify::<Initialized>(InitializedParams {});
         controller::dispatch_pending_editor_requests(ctx)
     });
 }
@@ -414,23 +465,25 @@ pub const CAPABILITY_SIGNATURE_HELP: &str = "lsp-signature-help";
 pub const CAPABILITY_TYPE_DEFINITION: &str = "lsp-type-definition";
 pub const CAPABILITY_WORKSPACE_SYMBOL: &str = "lsp-workspace-symbol";
 
-pub fn attempt_server_capability(ctx: &Context, meta: &EditorMeta, feature: &'static str) -> bool {
-    if server_has_capability(ctx, feature) {
+pub fn attempt_server_capability(
+    server: (&ServerName, &ServerSettings),
+    meta: &EditorMeta,
+    feature: &'static str,
+) -> bool {
+    let (server_name, server_settings) = server;
+    if server_has_capability(server_settings, feature) {
         return true;
     }
 
     if !meta.hook {
-        warn!(
-            "Server does not support {}, refusing to send request",
-            feature
-        );
+        warn!("{server_name} server does not support {feature}, refusing to send request");
     }
 
     false
 }
 
-pub fn server_has_capability(ctx: &Context, feature: &'static str) -> bool {
-    let server_capabilities = match ctx.capabilities.as_ref() {
+pub fn server_has_capability(server: &ServerSettings, feature: &'static str) -> bool {
+    let server_capabilities = match &server.capabilities {
         Some(caps) => caps,
         None => return false,
     };
@@ -529,80 +582,118 @@ pub fn server_has_capability(ctx: &Context, feature: &'static str) -> bool {
 }
 
 pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
-    let mut features: Vec<String> = vec![];
+    let mut features: BTreeMap<String, Vec<&ServerName>> = BTreeMap::new();
 
-    fn probe_feature(ctx: &mut Context, features: &mut Vec<String>, feature: &'static str) {
-        if server_has_capability(ctx, feature) {
-            features.push(feature.to_string());
+    fn probe_feature<'a>(
+        server: (&'a ServerName, &'a ServerSettings),
+        features: &mut BTreeMap<String, Vec<&'a ServerName>>,
+        feature: &'static str,
+    ) {
+        let (server_name, server_settings) = server;
+        if server_has_capability(server_settings, feature) {
+            features
+                .entry(feature.to_string())
+                .or_default()
+                .push(server_name);
         }
     }
 
-    probe_feature(ctx, &mut features, CAPABILITY_SELECTION_RANGE);
-    probe_feature(ctx, &mut features, CAPABILITY_HOVER);
-    probe_feature(ctx, &mut features, CAPABILITY_COMPLETION);
-    probe_feature(ctx, &mut features, CAPABILITY_SIGNATURE_HELP);
-    probe_feature(ctx, &mut features, CAPABILITY_DEFINITION);
-    probe_feature(ctx, &mut features, CAPABILITY_TYPE_DEFINITION);
-    probe_feature(ctx, &mut features, CAPABILITY_IMPLEMENTATION);
-    probe_feature(ctx, &mut features, CAPABILITY_REFERENCES);
-    probe_feature(ctx, &mut features, CAPABILITY_DOCUMENT_HIGHLIGHT);
-    if server_has_capability(ctx, CAPABILITY_DOCUMENT_SYMBOL) {
-        features.push("lsp-document-symbol, lsp-object, lsp-goto-document-symbol".to_string());
-    }
-    probe_feature(ctx, &mut features, CAPABILITY_WORKSPACE_SYMBOL);
-    probe_feature(ctx, &mut features, CAPABILITY_FORMATTING);
-    probe_feature(ctx, &mut features, CAPABILITY_RANGE_FORMATTING);
-    probe_feature(ctx, &mut features, CAPABILITY_RENAME);
-    probe_feature(ctx, &mut features, CAPABILITY_CODE_ACTIONS);
-    probe_feature(ctx, &mut features, CAPABILITY_CODE_ACTIONS_RESOLVE);
-    probe_feature(ctx, &mut features, CAPABILITY_CODE_LENS);
-    probe_feature(ctx, &mut features, CAPABILITY_CALL_HIERARCHY);
-    features.push("lsp-diagnostics".to_string());
-    probe_feature(ctx, &mut features, CAPABILITY_INLAY_HINTS);
+    for entry in &ctx.language_servers {
+        let (server_name, server_settings) = entry;
 
-    // NOTE controller should park request for capabilities until they are available thus it should
-    // be safe to unwrap here (otherwise something unexpectedly wrong and it's better to panic)
-    let server_capabilities = ctx.capabilities.as_ref().unwrap();
+        probe_feature(entry, &mut features, CAPABILITY_SELECTION_RANGE);
+        probe_feature(entry, &mut features, CAPABILITY_HOVER);
+        probe_feature(entry, &mut features, CAPABILITY_COMPLETION);
+        probe_feature(entry, &mut features, CAPABILITY_SIGNATURE_HELP);
+        probe_feature(entry, &mut features, CAPABILITY_DEFINITION);
+        probe_feature(entry, &mut features, CAPABILITY_TYPE_DEFINITION);
+        probe_feature(entry, &mut features, CAPABILITY_IMPLEMENTATION);
+        probe_feature(entry, &mut features, CAPABILITY_REFERENCES);
+        probe_feature(entry, &mut features, CAPABILITY_DOCUMENT_HIGHLIGHT);
+        if server_has_capability(server_settings, CAPABILITY_DOCUMENT_SYMBOL) {
+            features
+                .entry("lsp-document-symbol, lsp-object, lsp-goto-document-symbol".to_string())
+                .or_default()
+                .push(server_name);
+        }
+        probe_feature(entry, &mut features, CAPABILITY_WORKSPACE_SYMBOL);
+        probe_feature(entry, &mut features, CAPABILITY_FORMATTING);
+        probe_feature(entry, &mut features, CAPABILITY_RANGE_FORMATTING);
+        probe_feature(entry, &mut features, CAPABILITY_RENAME);
+        probe_feature(entry, &mut features, CAPABILITY_CODE_ACTIONS);
+        probe_feature(entry, &mut features, CAPABILITY_CODE_ACTIONS_RESOLVE);
+        probe_feature(entry, &mut features, CAPABILITY_CODE_LENS);
+        probe_feature(entry, &mut features, CAPABILITY_CALL_HIERARCHY);
+        features
+            .entry("lsp-diagnostics".to_string())
+            .or_default()
+            .push(server_name);
+        probe_feature(entry, &mut features, CAPABILITY_INLAY_HINTS);
 
-    if let Some(ref provider) = server_capabilities.execute_command_provider {
-        features.push(format!(
-            "lsp-execute-command:  commands: [{}]",
-            provider.commands.iter().join(", ")
-        ))
-    }
+        // NOTE controller should park request for capabilities until they are available thus it should
+        // be safe to unwrap here (otherwise something unexpectedly wrong and it's better to panic)
+        let server_capabilities = server_settings.capabilities.as_ref().unwrap();
 
-    if let Some(ref provider) = server_capabilities.semantic_tokens_provider {
-        let legend = match provider {
-            SemanticTokensServerCapabilities::SemanticTokensOptions(options) => &options.legend,
-            SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(regopts) => {
-                &regopts.semantic_tokens_options.legend
-            }
-        };
+        if let Some(ref provider) = server_capabilities.execute_command_provider {
+            features
+                .entry(format!(
+                    "lsp-execute-command: commands: [{}]",
+                    provider.commands.iter().join(", ")
+                ))
+                .or_default()
+                .push(server_name);
+        }
 
-        features.push(format!(
-            "lsp-semantic-tokens:     types: [{}]",
-            legend
-                .token_types
-                .iter()
-                .map(SemanticTokenType::as_str)
-                .join(", ")
-        ));
-        features.push(format!(
-            "lsp-semantic-tokens: modifiers: [{}]",
-            legend
-                .token_modifiers
-                .iter()
-                .map(SemanticTokenModifier::as_str)
-                .join(", ")
-        ));
+        if let Some(ref provider) = server_capabilities.semantic_tokens_provider {
+            let legend = match provider {
+                SemanticTokensServerCapabilities::SemanticTokensOptions(options) => &options.legend,
+                SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(regopts) => {
+                    &regopts.semantic_tokens_options.legend
+                }
+            };
+
+            features
+                .entry(format!(
+                    "lsp-semantic-tokens: types: [{}]",
+                    legend
+                        .token_types
+                        .iter()
+                        .map(SemanticTokenType::as_str)
+                        .join(", ")
+                ))
+                .or_default()
+                .push(server_name);
+            features
+                .entry(format!(
+                    "lsp-semantic-tokens: modifiers: [{}]",
+                    legend
+                        .token_modifiers
+                        .iter()
+                        .map(SemanticTokenModifier::as_str)
+                        .join(", ")
+                ))
+                .or_default()
+                .push(server_name);
+        }
     }
 
     let command = formatdoc!(
-        "info 'kak-lsp commands supported by {} language server:
+        "info 'kak-lsp commands supported by language servers ({}):
 
          {}'",
-        ctx.language_id,
-        editor_escape(&features.join("\n"))
+        editor_escape(&ctx.language_servers.keys().join(", ")),
+        editor_escape(
+            &features
+                .into_iter()
+                .map(|(feature, server_names)| {
+                    if ctx.language_servers.len() > 1 {
+                        format!("{} [{}]", feature, server_names.iter().join(", "))
+                    } else {
+                        feature
+                    }
+                })
+                .join("\n")
+        )
     );
     ctx.exec(meta, command);
 }

--- a/src/language_features/clangd.rs
+++ b/src/language_features/clangd.rs
@@ -13,13 +13,28 @@ impl Request for SwitchSourceHeaderRequest {
 }
 
 pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
-    let req_params = TextDocumentIdentifier {
-        uri: Url::from_file_path(&meta.buffile).unwrap(),
-    };
+    let req_params = ctx
+        .language_servers
+        .keys()
+        .map(|server_name| {
+            (
+                server_name.clone(),
+                vec![TextDocumentIdentifier {
+                    uri: Url::from_file_path(&meta.buffile).unwrap(),
+                }],
+            )
+        })
+        .collect();
+
     ctx.call::<SwitchSourceHeaderRequest, _>(
         meta,
-        req_params,
-        move |ctx: &mut Context, meta, response| {
+        RequestParams::Each(req_params),
+        move |ctx, meta, results| {
+            let response = match results.into_iter().find(|(_, v)| v.is_some()) {
+                Some((_, result)) => result,
+                None => None,
+            };
+
             if let Some(response) = response {
                 let command = format!(
                     "evaluate-commands -try-client %opt{{jumpclient}} -verbatim -- edit -existing {}",

--- a/src/language_features/code_action.rs
+++ b/src/language_features/code_action.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
 use crate::capabilities::attempt_server_capability;
 use crate::capabilities::CAPABILITY_CODE_ACTIONS;
 use crate::capabilities::CAPABILITY_CODE_ACTIONS_RESOLVE;
@@ -15,7 +18,12 @@ use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_code_action(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    if meta.fifo.is_none() && !attempt_server_capability(ctx, &meta, CAPABILITY_CODE_ACTIONS) {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|srv| attempt_server_capability(*srv, &meta, CAPABILITY_CODE_ACTIONS))
+        .collect();
+    if meta.fifo.is_none() && eligible_servers.is_empty() {
         return;
     }
 
@@ -33,84 +41,142 @@ pub fn text_document_code_action(meta: EditorMeta, params: EditorParams, ctx: &m
             return;
         }
     };
-    let range = kakoune_range_to_lsp(
-        &parse_kakoune_range(&params.selection_desc).0,
-        &document.text,
-        ctx.offset_encoding,
-    );
-    code_actions_for_range(meta, params, ctx, range)
+    let ranges = eligible_servers
+        .into_iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                kakoune_range_to_lsp(
+                    &parse_kakoune_range(&params.selection_desc).0,
+                    &document.text,
+                    server_settings.offset_encoding,
+                ),
+            )
+        })
+        .collect();
+    code_actions_for_ranges(meta, params, ctx, ranges)
 }
 
-fn code_actions_for_range(
+fn code_actions_for_ranges(
     meta: EditorMeta,
     params: CodeActionsParams,
     ctx: &mut Context,
-    range: Range,
+    ranges: HashMap<ServerName, Range>,
 ) {
     let buff_diags = ctx.diagnostics.get(&meta.buffile);
 
-    let diagnostics: Vec<Diagnostic> = if let Some(buff_diags) = buff_diags {
+    let mut diagnostics: HashMap<ServerName, Vec<Diagnostic>> = if let Some(buff_diags) = buff_diags
+    {
         buff_diags
             .iter()
-            .filter(|d| ranges_overlap(d.range, range))
+            .filter(|(server_name, d)| ranges_overlap(d.range, ranges[server_name]))
             .cloned()
-            .collect()
+            .fold(HashMap::new(), |mut m, v| {
+                let (server_name, diagnostic) = v;
+                m.entry(server_name).or_default().push(diagnostic);
+                m
+            })
     } else {
-        Vec::new()
+        HashMap::new()
     };
 
-    let req_params = CodeActionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
-        },
-        range,
-        context: CodeActionContext {
-            diagnostics,
-            only: None,
-            trigger_kind: Some(if meta.hook {
-                CodeActionTriggerKind::AUTOMATIC
-            } else {
-                CodeActionTriggerKind::INVOKED
-            }),
-        },
-        work_done_progress_params: Default::default(),
-        partial_result_params: Default::default(),
-    };
-    ctx.call::<CodeActionRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        editor_code_actions(meta, result, ctx, params, range)
-    });
+    let req_params = ranges
+        .iter()
+        .map(|(server_name, range)| {
+            (
+                server_name.clone(),
+                vec![CodeActionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                    },
+                    range: *range,
+                    context: CodeActionContext {
+                        diagnostics: diagnostics.remove(server_name).unwrap_or_default(),
+                        only: None,
+                        trigger_kind: Some(if meta.hook {
+                            CodeActionTriggerKind::AUTOMATIC
+                        } else {
+                            CodeActionTriggerKind::INVOKED
+                        }),
+                    },
+                    work_done_progress_params: Default::default(),
+                    partial_result_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<CodeActionRequest, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx, meta, results| editor_code_actions(meta, results, ctx, params, ranges),
+    );
 }
 
 fn editor_code_actions(
     meta: EditorMeta,
-    result: Option<CodeActionResponse>,
+    results: Vec<(ServerName, Option<CodeActionResponse>)>,
     ctx: &mut Context,
     params: CodeActionsParams,
-    mut range: Range,
+    mut ranges: HashMap<ServerName, Range>,
 ) {
     if !meta.hook
-        && result == Some(vec![])
-        && range.start.character != 0
-        && range.end.character != EOL_OFFSET
+        && results
+            .iter()
+            .all(|(server_name, result)| match ranges.get(server_name) {
+                Some(range) => {
+                    result == &Some(vec![])
+                        && range.start.character != 0
+                        && range.end.character != EOL_OFFSET
+                }
+                // Range is not registered for the language server,
+                // so let's not let it influence in whether we should
+                // reset the range and re-run code actions.
+                None => true,
+            })
     {
         // Some servers send code actions only if the requested range includes the affected
         // AST nodes.  Let's make them more convenient to access by requesting on whole lines.
-        range.start.character = 0;
-        range.end.character = EOL_OFFSET;
-        code_actions_for_range(meta, params, ctx, range);
+        for range in ranges.values_mut() {
+            range.start.character = 0;
+            range.end.character = EOL_OFFSET;
+        }
+        code_actions_for_ranges(meta, params, ctx, ranges);
         return;
     }
 
-    let actions = result.unwrap_or_default();
+    let actions: Vec<_> = results
+        .into_iter()
+        .flat_map(|(server_name, cmd)| {
+            let cmd: Vec<_> = cmd
+                .unwrap_or_default()
+                .into_iter()
+                .map(|cmd| (server_name.clone(), cmd))
+                .collect();
+            cmd
+        })
+        .collect();
 
-    for cmd in &actions {
+    for (_, cmd) in &actions {
         match cmd {
             CodeActionOrCommand::Command(cmd) => info!("Command: {:?}", cmd),
             CodeActionOrCommand::CodeAction(action) => info!("Action: {:?}", action),
         }
     }
 
-    let may_resolve = attempt_server_capability(ctx, &meta, CAPABILITY_CODE_ACTIONS_RESOLVE);
+    let may_resolve: HashSet<_> = ranges
+        .iter()
+        .filter(|(server_name, _)| {
+            let server_name = *server_name;
+            let server_settings = &ctx.language_servers[server_name];
+
+            attempt_server_capability(
+                (server_name, server_settings),
+                &meta,
+                CAPABILITY_CODE_ACTIONS_RESOLVE,
+            )
+        })
+        .map(|(server_name, _)| server_name)
+        .collect();
 
     if let Some(pattern) = params.code_action_pattern.as_ref() {
         let regex = match regex::Regex::new(pattern) {
@@ -126,7 +192,7 @@ fn editor_code_actions(
         };
         let matches = actions
             .iter()
-            .filter(|c| {
+            .filter(|(_, c)| {
                 let title = match c {
                     CodeActionOrCommand::Command(command) => &command.title,
                     CodeActionOrCommand::CodeAction(action) => &action.title,
@@ -145,7 +211,11 @@ fn editor_code_actions(
         .to_string();
         let command = match matches.len() {
             0 => fail + " 'no matching action available'",
-            1 => code_action_or_command_to_editor_command(matches[0], sync, may_resolve),
+            1 => {
+                let (server_name, cmd) = matches[0];
+                let may_resolve = may_resolve.contains(server_name);
+                code_action_or_command_to_editor_command(cmd, sync, may_resolve)
+            }
             _ => fail + " 'multiple matching actions'",
         };
         ctx.exec(meta, command);
@@ -154,7 +224,7 @@ fn editor_code_actions(
 
     let titles_and_commands = actions
         .iter()
-        .map(|c| {
+        .map(|(server_name, c)| {
             let mut title: &str = match c {
                 CodeActionOrCommand::Command(command) => &command.title,
                 CodeActionOrCommand::CodeAction(action) => &action.title,
@@ -162,6 +232,7 @@ fn editor_code_actions(
             if let Some((head, _)) = title.split_once('\n') {
                 title = head
             }
+            let may_resolve = may_resolve.contains(server_name);
             let select_cmd = code_action_or_command_to_editor_command(c, false, may_resolve);
             format!("{} {}", editor_quote(title), editor_quote(&select_cmd))
         })
@@ -267,13 +338,16 @@ pub fn text_document_code_action_resolve(
 ) {
     let params = CodeActionResolveParams::deserialize(params)
         .expect("Params should follow CodeActionResolveParams structure");
+    let req_params = serde_json::from_str(&params.code_action).unwrap();
 
     ctx.call::<CodeActionResolveRequest, _>(
         meta,
-        serde_json::from_str(&params.code_action).unwrap(),
-        move |ctx: &mut Context, meta, result| {
-            let cmd = code_action_to_editor_command(&result, false, false);
-            ctx.exec(meta, cmd)
+        RequestParams::All(vec![req_params]),
+        move |ctx: &mut Context, meta, results| {
+            if let Some((_, result)) = results.first() {
+                let cmd = code_action_to_editor_command(result, false, false);
+                ctx.exec(meta, cmd)
+            }
         },
     );
 }

--- a/src/language_features/code_lens.rs
+++ b/src/language_features/code_lens.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::code_action::execute_command_editor_command;
 use crate::capabilities::CAPABILITY_CODE_LENS;
 use crate::capabilities::CAPABILITY_EXECUTE_COMMANDS;
@@ -17,9 +19,15 @@ use lsp_types::*;
 use serde::Deserialize;
 
 pub fn text_document_code_lens(meta: EditorMeta, ctx: &mut Context) {
-    if !server_has_capability(ctx, CAPABILITY_CODE_LENS)
-        || !server_has_capability(ctx, CAPABILITY_EXECUTE_COMMANDS)
-    {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|(_, server)| {
+            server_has_capability(server, CAPABILITY_CODE_LENS)
+                && server_has_capability(server, CAPABILITY_EXECUTE_COMMANDS)
+        })
+        .collect();
+    if eligible_servers.is_empty() {
         return;
     }
 
@@ -30,14 +38,27 @@ pub fn text_document_code_lens(meta: EditorMeta, ctx: &mut Context) {
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),
     };
-    ctx.call::<CodeLensRequest, _>(meta, req_params, |ctx: &mut Context, meta, result| {
-        editor_code_lens(meta, result, ctx)
-    });
+    ctx.call::<CodeLensRequest, _>(
+        meta,
+        RequestParams::All(vec![req_params]),
+        |ctx: &mut Context, meta, results| editor_code_lens(meta, results, ctx),
+    );
 }
 
-fn editor_code_lens(meta: EditorMeta, result: Option<Vec<CodeLens>>, ctx: &mut Context) {
-    let mut lenses = result.unwrap_or_default();
-    lenses.sort_by_key(|lens| lens.range.start);
+fn editor_code_lens(
+    meta: EditorMeta,
+    results: Vec<(ServerName, Option<Vec<CodeLens>>)>,
+    ctx: &mut Context,
+) {
+    let mut lenses: Vec<_> = results
+        .into_iter()
+        .flat_map(|(server_name, v)| {
+            v.unwrap_or_default()
+                .into_iter()
+                .map(move |v| (server_name.clone(), v))
+        })
+        .collect();
+    lenses.sort_by_key(|(_, lens)| lens.range.start);
 
     let buffile = &meta.buffile;
     let document = match ctx.documents.get(buffile) {
@@ -50,10 +71,11 @@ fn editor_code_lens(meta: EditorMeta, result: Option<Vec<CodeLens>>, ctx: &mut C
     let version = document.version;
     let range_specs = lenses
         .iter()
-        .map(|lens| {
+        .map(|(server_name, lens)| {
+            let server = &ctx.language_servers[server_name];
             let label = lens.command.as_ref().map_or("", |v| &v.title);
             let position =
-                lsp_position_to_kakoune(&lens.range.start, &document.text, ctx.offset_encoding);
+                lsp_position_to_kakoune(&lens.range.start, &document.text, server.offset_encoding);
             let line = position.line;
             let column = position.column;
             lazy_static! {
@@ -99,22 +121,30 @@ pub fn resolve_and_perform_code_lens(meta: EditorMeta, params: EditorParams, ctx
         Some(document) => document,
         None => return,
     };
-    let range = kakoune_range_to_lsp(&range, &document.text, ctx.offset_encoding);
 
-    if let Some(lens) = ctx
+    if let Some((server_name, lens)) = ctx
         .code_lenses
         .get(&meta.buffile)
         .and_then(|lenses| {
-            lenses
-                .iter()
-                .find(|lens| ranges_touch_same_line(lens.range, range))
+            lenses.iter().find(|(server_name, lens)| {
+                let ServerSettings {
+                    offset_encoding, ..
+                } = &ctx.language_servers[server_name];
+                let range = kakoune_range_to_lsp(&range, &document.text, *offset_encoding);
+                ranges_touch_same_line(lens.range, range)
+            })
         })
-        .filter(|lens| lens.command.is_none())
+        .filter(|(_, lens)| lens.command.is_none())
         .cloned()
     {
-        ctx.call::<CodeLensResolve, _>(meta, lens, |ctx: &mut Context, meta, lens| {
-            perform_code_lens(meta, &[&lens], ctx)
-        });
+        let mut req_params = HashMap::new();
+        req_params.insert(server_name, vec![lens]);
+
+        ctx.call::<CodeLensResolve, _>(
+            meta,
+            RequestParams::Each(req_params),
+            |ctx: &mut Context, meta, results| perform_code_lens(meta, &results, ctx),
+        );
         return;
     }
 
@@ -124,7 +154,14 @@ pub fn resolve_and_perform_code_lens(meta: EditorMeta, params: EditorParams, ctx
     };
     let lenses = lenses
         .iter()
-        .filter(|lens| ranges_touch_same_line(lens.range, range))
+        .filter(|(server_name, lens)| {
+            let ServerSettings {
+                offset_encoding, ..
+            } = &ctx.language_servers[server_name];
+            let range = kakoune_range_to_lsp(&range, &document.text, *offset_encoding);
+            ranges_touch_same_line(lens.range, range)
+        })
+        .map(|(a, b)| (a.clone(), b.clone()))
         .collect::<Vec<_>>();
 
     if lenses.is_empty() {
@@ -135,13 +172,13 @@ pub fn resolve_and_perform_code_lens(meta: EditorMeta, params: EditorParams, ctx
     perform_code_lens(meta, &lenses, ctx);
 }
 
-fn perform_code_lens(meta: EditorMeta, lenses: &[&CodeLens], ctx: &Context) {
+fn perform_code_lens(meta: EditorMeta, lenses: &[(ServerName, CodeLens)], ctx: &Context) {
     let command = format!(
         "lsp-perform-code-lens {}",
         lenses
             .iter()
-            .filter(|lens| lens.command.is_some())
-            .map(|lens| {
+            .filter(|(_, lens)| lens.command.is_some())
+            .map(|(_, lens)| {
                 let command = lens.command.as_ref().unwrap();
                 format!(
                     "{} {}",

--- a/src/language_features/cquery.rs
+++ b/src/language_features/cquery.rs
@@ -1,5 +1,6 @@
 use crate::context::*;
 use crate::position::*;
+use crate::types::ServerName;
 use crate::util::*;
 use itertools::Itertools;
 use jsonrpc_core::Params;
@@ -154,7 +155,7 @@ pub struct PublishSemanticHighlightingParams {
     pub symbols: Vec<SemanticSymbol>,
 }
 
-pub fn publish_semantic_highlighting(params: Params, ctx: &mut Context) {
+pub fn publish_semantic_highlighting(server_name: &ServerName, params: Params, ctx: &mut Context) {
     let params: PublishSemanticHighlightingParams =
         params.parse().expect("Failed to parse semhl params");
     let client = None;
@@ -166,12 +167,13 @@ pub fn publish_semantic_highlighting(params: Params, ctx: &mut Context) {
     }
     let document = document.unwrap();
     let version = document.version;
+    let server = &ctx.language_servers[server_name];
     let ranges = params
         .symbols
         .iter()
         .flat_map(|x| {
             let face = x.get_face();
-            let offset_encoding = ctx.offset_encoding;
+            let offset_encoding = server.offset_encoding;
             x.ranges.iter().filter_map(move |r| {
                 if face.is_empty() {
                     warn!("No face found for {:?}", x);

--- a/src/language_features/eclipse_jdt_ls.rs
+++ b/src/language_features/eclipse_jdt_ls.rs
@@ -6,17 +6,32 @@ use lsp_types::*;
 
 pub fn organize_imports(meta: EditorMeta, ctx: &mut Context) {
     let file_uri = Url::from_file_path(&meta.buffile).unwrap();
-
     let file_uri: String = file_uri.into();
-    let req_params = ExecuteCommandParams {
-        command: "java.edit.organizeImports".to_string(),
-        arguments: vec![serde_json::json!(file_uri)],
-        ..ExecuteCommandParams::default()
-    };
+
+    let req_params = ctx
+        .language_servers
+        .keys()
+        .map(|server_name| {
+            (
+                server_name.clone(),
+                vec![ExecuteCommandParams {
+                    command: "java.edit.organizeImports".to_string(),
+                    arguments: vec![serde_json::json!(file_uri)],
+                    ..ExecuteCommandParams::default()
+                }],
+            )
+        })
+        .collect();
+
     ctx.call::<ExecuteCommand, _>(
         meta,
-        req_params,
-        move |ctx: &mut Context, meta, response| {
+        RequestParams::Each(req_params),
+        move |ctx, meta, results| {
+            let response = match results.into_iter().find(|(_, v)| v.is_some()) {
+                Some((_, result)) => result,
+                None => None,
+            };
+
             if let Some(response) = response {
                 organize_imports_response(meta, serde_json::from_value(response).unwrap(), ctx);
             }

--- a/src/language_features/formatting.rs
+++ b/src/language_features/formatting.rs
@@ -1,31 +1,76 @@
+use std::collections::HashMap;
+
 use crate::capabilities::{attempt_server_capability, CAPABILITY_FORMATTING};
 use crate::context::*;
 use crate::types::*;
+use crate::util::editor_quote;
+use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
 use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_formatting(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    if meta.fifo.is_none() && !attempt_server_capability(ctx, &meta, CAPABILITY_FORMATTING) {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|server| attempt_server_capability(*server, &meta, CAPABILITY_FORMATTING))
+        .filter(|(server_name, _)| {
+            if let Some(fmt_server) = &meta.server {
+                *server_name == fmt_server
+            } else {
+                true
+            }
+        })
+        .collect();
+    if meta.fifo.is_none() && eligible_servers.is_empty() {
+        return;
+    }
+
+    // Ask user to pick which server to use for formatting when multiple options are available.
+    if eligible_servers.len() > 1 {
+        let choices = eligible_servers
+            .into_iter()
+            .map(|(server_name, _)| {
+                let cmd = if meta.fifo.is_some() {
+                    "lsp-formatting-sync"
+                } else {
+                    "lsp-formatting"
+                };
+                let cmd = format!("{} {}", cmd, server_name);
+                format!("{} {}", editor_quote(server_name), editor_quote(&cmd))
+            })
+            .join(" ");
+        ctx.exec(meta, format!("lsp-menu {}", choices));
         return;
     }
 
     let params = FormattingOptions::deserialize(params)
         .expect("Params should follow FormattingOptions structure");
-    let req_params = DocumentFormattingParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
-        },
-        options: params,
-        work_done_progress_params: Default::default(),
-    };
+
+    let (server_name, _) = eligible_servers[0];
+    let mut req_params = HashMap::new();
+    req_params.insert(
+        server_name.clone(),
+        vec![DocumentFormattingParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            options: params.clone(),
+            work_done_progress_params: Default::default(),
+        }],
+    );
+
+    let server_name = server_name.clone();
     ctx.call::<Formatting, _>(
         meta,
-        req_params,
-        move |ctx: &mut Context, meta: EditorMeta, result: Option<Vec<TextEdit>>| {
-            let text_edits = result.unwrap_or_default();
-            super::range_formatting::editor_range_formatting(meta, text_edits, ctx)
+        RequestParams::Each(req_params),
+        move |ctx, meta, mut results| {
+            let text_edits = results
+                .first_mut()
+                .and_then(|(_, v)| v.take())
+                .unwrap_or_default();
+            super::range_formatting::editor_range_formatting(meta, (server_name, text_edits), ctx)
         },
     );
 }

--- a/src/language_features/goto.rs
+++ b/src/language_features/goto.rs
@@ -1,32 +1,55 @@
-use crate::context::Context;
+use crate::context::{Context, RequestParams, ServerSettings};
 use crate::position::*;
-use crate::types::{EditorMeta, EditorParams, KakouneRange, PositionParams};
+use crate::types::{EditorMeta, EditorParams, KakouneRange, PositionParams, ServerName};
 use crate::util::{editor_quote, short_file_path};
 use indoc::formatdoc;
 use itertools::Itertools;
 use lsp_types::request::{
-    GotoDeclaration, GotoDefinition, GotoImplementation, GotoTypeDefinition, References,
+    GotoDeclaration, GotoDefinition, GotoImplementation, GotoTypeDefinition,
+    GotoTypeDefinitionResponse, References,
 };
 use lsp_types::*;
 use serde::Deserialize;
 use url::Url;
 
-pub fn goto(meta: EditorMeta, result: Option<GotoDefinitionResponse>, ctx: &mut Context) {
-    let locations = match result {
-        Some(GotoDefinitionResponse::Scalar(location)) => vec![location],
-        Some(GotoDefinitionResponse::Array(locations)) => locations,
-        Some(GotoDefinitionResponse::Link(locations)) => locations
-            .into_iter()
-            .map(
-                |LocationLink {
-                     target_uri: uri,
-                     target_selection_range: range,
-                     ..
-                 }| Location { uri, range },
-            )
-            .collect(),
-        None => return,
-    };
+pub fn goto(
+    meta: EditorMeta,
+    results: Vec<(ServerName, Option<GotoDefinitionResponse>)>,
+    ctx: &mut Context,
+) {
+    // HACK: When using multiple language servers, we might get duplicates here. Filter them out.
+    let mut seen: Vec<GotoDefinitionResponse> = vec![];
+    let locations: Vec<_> = results
+        .into_iter()
+        .filter_map(|(server_name, v)| match v {
+            None => None,
+            Some(response) => {
+                if seen.iter().any(|r| *r == response) {
+                    return None;
+                }
+                seen.push(response.clone());
+                Some((server_name, response))
+            }
+        })
+        .flat_map(|(server_name, response)| match response {
+            GotoDefinitionResponse::Scalar(location) => vec![(server_name, location)],
+            GotoDefinitionResponse::Array(locations) => locations
+                .into_iter()
+                .map(|v| (server_name.clone(), v))
+                .collect(),
+            GotoDefinitionResponse::Link(locations) => locations
+                .into_iter()
+                .map(
+                    |LocationLink {
+                         target_uri: uri,
+                         target_selection_range: range,
+                         ..
+                     }| (server_name.clone(), Location { uri, range }),
+                )
+                .collect(),
+        })
+        .collect();
+
     match locations.len() {
         0 => {}
         1 => {
@@ -48,11 +71,16 @@ pub fn edit_at_range(buffile: &str, range: KakouneRange) -> String {
     )
 }
 
-fn goto_location(meta: EditorMeta, Location { uri, range }: &Location, ctx: &mut Context) {
+fn goto_location(
+    meta: EditorMeta,
+    (server_name, Location { uri, range }): &(ServerName, Location),
+    ctx: &mut Context,
+) {
     let path = uri.to_file_path().unwrap();
     let path_str = path.to_str().unwrap();
     if let Some(contents) = get_file_contents(path_str, ctx) {
-        let range = lsp_range_to_kakoune(range, &contents, ctx.offset_encoding);
+        let server = &ctx.language_servers[server_name];
+        let range = lsp_range_to_kakoune(range, &contents, server.offset_encoding);
         let command = format!(
             "evaluate-commands -try-client %opt{{jumpclient}} -- {}",
             editor_quote(&edit_at_range(path_str, range)),
@@ -61,10 +89,13 @@ fn goto_location(meta: EditorMeta, Location { uri, range }: &Location, ctx: &mut
     }
 }
 
-fn goto_locations(meta: EditorMeta, locations: &[Location], ctx: &mut Context) {
+fn goto_locations(meta: EditorMeta, locations: &[(ServerName, Location)], ctx: &mut Context) {
+    let server_entry = ctx.language_servers.first_entry().unwrap();
+    let ServerSettings { root_path, .. } = server_entry.get();
+    let main_root_path = root_path.clone();
     let select_location = locations
         .iter()
-        .group_by(|Location { uri, .. }| uri.to_file_path().unwrap())
+        .group_by(|(_, Location { uri, .. })| uri.to_file_path().unwrap())
         .into_iter()
         .map(|(path, locations)| {
             let path_str = path.to_str().unwrap();
@@ -73,14 +104,17 @@ fn goto_locations(meta: EditorMeta, locations: &[Location], ctx: &mut Context) {
                 None => return "".into(),
             };
             locations
-                .map(|Location { range, .. }| {
-                    let pos = lsp_range_to_kakoune(range, &contents, ctx.offset_encoding).start;
+                .map(|(server_name, Location { range, .. })| {
+                    let server = &ctx.language_servers[server_name];
+                    let pos = lsp_range_to_kakoune(range, &contents, server.offset_encoding).start;
                     if range.start.line as usize >= contents.len_lines() {
                         return "".into();
                     }
+                    // Let's use the main server root path to dictate how
+                    // file paths should look like in the goto buffer.
                     format!(
                         "{}:{}:{}:{}",
-                        short_file_path(path_str, &ctx.root_path),
+                        short_file_path(path_str, &main_root_path),
                         pos.line,
                         pos.column,
                         contents.line(range.start.line as usize),
@@ -91,7 +125,7 @@ fn goto_locations(meta: EditorMeta, locations: &[Location], ctx: &mut Context) {
         .join("");
     let command = format!(
         "lsp-show-goto-choices {} {}",
-        editor_quote(&ctx.root_path),
+        editor_quote(&main_root_path),
         editor_quote(&select_location),
     );
     ctx.exec(meta, command);
@@ -104,77 +138,152 @@ pub fn text_document_definition(
     ctx: &mut Context,
 ) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = GotoDefinitionParams {
-        text_document_position_params: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
-        },
-        partial_result_params: Default::default(),
-        work_done_progress_params: Default::default(),
-    };
+    let req_params = ctx
+        .language_servers
+        .iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(
+                            server_settings,
+                            &meta.buffile,
+                            &params.position,
+                            ctx,
+                        )
+                        .unwrap(),
+                    },
+                    partial_result_params: Default::default(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    let req_params = RequestParams::Each(req_params);
     if declaration {
-        ctx.call::<GotoDeclaration, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-            goto(meta, result, ctx);
-        });
+        ctx.call::<GotoDeclaration, _>(
+            meta,
+            req_params,
+            move |ctx: &mut Context, meta, results| goto(meta, results, ctx),
+        );
     } else {
-        ctx.call::<GotoDefinition, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-            goto(meta, result, ctx);
+        ctx.call::<GotoDefinition, _>(meta, req_params, move |ctx: &mut Context, meta, results| {
+            goto(meta, results, ctx)
         });
     }
 }
 
 pub fn text_document_implementation(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = GotoDefinitionParams {
-        text_document_position_params: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
-        },
-        partial_result_params: Default::default(),
-        work_done_progress_params: Default::default(),
-    };
-    ctx.call::<GotoImplementation, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        goto(meta, result, ctx);
-    });
+    let req_params = ctx
+        .language_servers
+        .iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(
+                            server_settings,
+                            &meta.buffile,
+                            &params.position,
+                            ctx,
+                        )
+                        .unwrap(),
+                    },
+                    partial_result_params: Default::default(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<GotoImplementation, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| goto(meta, results, ctx),
+    );
 }
 
 pub fn text_document_type_definition(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = GotoDefinitionParams {
-        text_document_position_params: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
-        },
-        partial_result_params: Default::default(),
-        work_done_progress_params: Default::default(),
-    };
-    ctx.call::<GotoTypeDefinition, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        goto(meta, result, ctx);
-    });
+    let req_params = ctx
+        .language_servers
+        .iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![GotoDefinitionParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(
+                            server_settings,
+                            &meta.buffile,
+                            &params.position,
+                            ctx,
+                        )
+                        .unwrap(),
+                    },
+                    partial_result_params: Default::default(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<GotoTypeDefinition, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| goto(meta, results, ctx),
+    );
 }
 
 pub fn text_document_references(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = ReferenceParams {
-        text_document_position: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+    let req_params = ctx
+        .language_servers
+        .iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![ReferenceParams {
+                    text_document_position: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(
+                            server_settings,
+                            &meta.buffile,
+                            &params.position,
+                            ctx,
+                        )
+                        .unwrap(),
+                    },
+                    context: ReferenceContext {
+                        include_declaration: true,
+                    },
+                    partial_result_params: Default::default(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<References, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| {
+            let results = results
+                .into_iter()
+                .map(|(server_name, loc)| (server_name, loc.map(GotoTypeDefinitionResponse::Array)))
+                .collect();
+            goto(meta, results, ctx);
         },
-        context: ReferenceContext {
-            include_declaration: true,
-        },
-        partial_result_params: Default::default(),
-        work_done_progress_params: Default::default(),
-    };
-    ctx.call::<References, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        goto(meta, result.map(GotoDefinitionResponse::Array), ctx);
-    });
+    );
 }

--- a/src/language_features/highlight.rs
+++ b/src/language_features/highlight.rs
@@ -1,7 +1,9 @@
 use crate::capabilities::{attempt_server_capability, CAPABILITY_DOCUMENT_HIGHLIGHT};
-use crate::context::Context;
+use crate::context::{Context, RequestParams};
 use crate::position::*;
-use crate::types::{EditorMeta, EditorParams, KakounePosition, KakouneRange, PositionParams};
+use crate::types::{
+    EditorMeta, EditorParams, KakounePosition, KakouneRange, PositionParams, ServerName,
+};
 use crate::util::editor_quote;
 use itertools::Itertools;
 use lsp_types::{
@@ -12,26 +14,52 @@ use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_highlight(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    if meta.fifo.is_none() && !attempt_server_capability(ctx, &meta, CAPABILITY_DOCUMENT_HIGHLIGHT)
-    {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|srv| attempt_server_capability(*srv, &meta, CAPABILITY_DOCUMENT_HIGHLIGHT))
+        .collect();
+    if meta.fifo.is_none() && eligible_servers.is_empty() {
         return;
     }
 
+    let (first_server, _) = eligible_servers.first().unwrap();
+    let first_server = first_server.to_string();
+
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = DocumentHighlightParams {
-        text_document_position_params: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
-        },
-        partial_result_params: Default::default(),
-        work_done_progress_params: Default::default(),
-    };
+    let req_params = eligible_servers
+        .into_iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![DocumentHighlightParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(
+                            server_settings,
+                            &meta.buffile,
+                            &params.position,
+                            ctx,
+                        )
+                        .unwrap(),
+                    },
+                    partial_result_params: Default::default(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
     ctx.call::<DocumentHighlightRequest, _>(
         meta,
-        req_params,
-        move |ctx: &mut Context, meta, result| {
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| {
+            let result = match results.into_iter().find(|(_, v)| v.is_some()) {
+                Some(result) => result,
+                None => (first_server, Some(vec![])),
+            };
+
             editor_document_highlight(meta, result, params.position, ctx)
         },
     );
@@ -39,22 +67,24 @@ pub fn text_document_highlight(meta: EditorMeta, params: EditorParams, ctx: &mut
 
 fn editor_document_highlight(
     meta: EditorMeta,
-    result: Option<Vec<DocumentHighlight>>,
+    result: (ServerName, Option<Vec<DocumentHighlight>>),
     main_cursor: KakounePosition,
     ctx: &mut Context,
 ) {
+    let (server_name, result) = result;
     let document = ctx.documents.get(&meta.buffile);
     if document.is_none() {
         return;
     }
     let document = document.unwrap();
+    let server = &ctx.language_servers[&server_name];
     let mut ranges = vec![];
     let range_specs = match result {
         Some(highlights) => highlights
             .into_iter()
             .map(|highlight| {
                 let range =
-                    lsp_range_to_kakoune(&highlight.range, &document.text, ctx.offset_encoding);
+                    lsp_range_to_kakoune(&highlight.range, &document.text, server.offset_encoding);
                 ranges.push(range);
                 format!(
                     "{}|{}",

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::capabilities::attempt_server_capability;
 use crate::capabilities::CAPABILITY_HOVER;
 use crate::context::*;
@@ -14,7 +16,12 @@ use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_hover(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    if meta.fifo.is_none() && !attempt_server_capability(ctx, &meta, CAPABILITY_HOVER) {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|srv| attempt_server_capability(*srv, &meta, CAPABILITY_HOVER))
+        .collect();
+    if meta.fifo.is_none() && eligible_servers.is_empty() {
         return;
     }
 
@@ -29,18 +36,39 @@ pub fn text_document_hover(meta: EditorMeta, params: EditorParams, ctx: &mut Con
 
     let params = EditorHoverParams::deserialize(params).unwrap();
     let (range, cursor) = parse_kakoune_range(&params.selection_desc);
-    let req_params = HoverParams {
-        text_document_position_params: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &cursor, ctx).unwrap(),
+    let req_params = eligible_servers
+        .into_iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![HoverParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(server_settings, &meta.buffile, &cursor, ctx)
+                            .unwrap(),
+                    },
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<HoverRequest, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| {
+            editor_hover(
+                meta,
+                hover_type,
+                cursor,
+                range,
+                params.tabstop,
+                results,
+                ctx,
+            )
         },
-        work_done_progress_params: Default::default(),
-    };
-    ctx.call::<HoverRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        editor_hover(meta, hover_type, cursor, range, params.tabstop, result, ctx)
-    });
+    );
 }
 
 pub fn editor_hover(
@@ -49,28 +77,50 @@ pub fn editor_hover(
     cursor: KakounePosition,
     range: KakouneRange,
     tabstop: usize,
-    result: Option<Hover>,
+    results: Vec<(ServerName, Option<Hover>)>,
     ctx: &mut Context,
 ) {
     let doc = &ctx.documents[&meta.buffile];
-    let lsp_range = kakoune_range_to_lsp(&range, &doc.text, ctx.offset_encoding);
+    let lsp_ranges: HashMap<_, _> = results
+        .iter()
+        .map(|(server_name, _)| {
+            let offset_encoding = ctx.language_servers[server_name].offset_encoding;
+            (
+                server_name,
+                kakoune_range_to_lsp(&range, &doc.text, offset_encoding),
+            )
+        })
+        .collect();
     let for_hover_buffer = matches!(hover_type, HoverType::HoverBuffer { .. });
     let diagnostics = ctx.diagnostics.get(&meta.buffile);
     let diagnostics = diagnostics
         .map(|x| {
             x.iter()
-                .filter(|x| ranges_touch_same_line(x.range, lsp_range))
-                .filter(|x| !x.message.is_empty())
-                .map(|x| {
+                .filter(|(server_name, x)| {
+                    lsp_ranges
+                        .get(server_name)
+                        .filter(|lsp_range| ranges_touch_same_line(x.range, **lsp_range))
+                        .is_some()
+                })
+                .filter(|(_, x)| !x.message.is_empty())
+                .map(|(server_name, x)| {
+                    let server = &ctx.language_servers[server_name];
                     // Indent line breaks to the same level as the bullet point
                     let message = (x.message.trim().to_string()
-                        + &format_related_information(x, ctx)
+                        + &format_related_information(x, server_name, server, server, ctx)
                             .map(|s| "\n  ".to_string() + &s)
                             .unwrap_or_default())
                         .replace('\n', "\n  ");
                     if for_hover_buffer {
                         // We are typically creating Markdown, so use a standard Markdown enumerator.
-                        return format!("* {}", message);
+                        return format!(
+                            "* {}{message}",
+                            &if ctx.language_servers.len() > 1 {
+                                format!("[{server_name}] ")
+                            } else {
+                                "".to_string()
+                            }
+                        );
                     }
 
                     let face = x
@@ -88,15 +138,18 @@ pub fn editor_hover(
                         .unwrap_or(FACE_INFO_DEFAULT);
 
                     format!(
-                        "• {{{}}}{}{{{}}}",
-                        face,
+                        "• {}{{{face}}}{}{{{FACE_INFO_DEFAULT}}}",
+                        &if ctx.language_servers.len() > 1 {
+                            format!("[{server_name}] ")
+                        } else {
+                            "".to_string()
+                        },
                         escape_kakoune_markup(&message),
-                        FACE_INFO_DEFAULT,
                     )
                 })
                 .join("\n")
         })
-        .unwrap_or_else(String::new);
+        .unwrap_or_default();
 
     let code_lenses = ctx
         .code_lenses
@@ -104,20 +157,29 @@ pub fn editor_hover(
         .map(|lenses| {
             lenses
                 .iter()
-                .filter(|lens| ranges_touch_same_line(lens.range, lsp_range))
-                .map(|lens| {
-                    lens.command
-                        .as_ref()
-                        .map(|cmd| cmd.title.as_str())
-                        .unwrap_or("(unresolved)")
+                .filter(|(server_name, lens)| {
+                    lsp_ranges
+                        .get(server_name)
+                        .filter(|lsp_range| ranges_touch_same_line(lens.range, **lsp_range))
+                        .is_some()
                 })
-                .map(|title| {
+                .map(|(server_name, lens)| {
+                    (
+                        server_name,
+                        lens.command
+                            .as_ref()
+                            .map(|cmd| cmd.title.as_str())
+                            .unwrap_or("(unresolved)"),
+                    )
+                })
+                .map(|(server_name, title)| {
                     if for_hover_buffer {
                         // We are typically creating Markdown, so use a standard Markdown enumerator.
                         return format!("* {}", &title);
                     }
                     format!(
-                        "• {{{}}}{}{{{}}}",
+                        "• ({}) {{{}}}{}{{{}}}",
+                        server_name,
                         FACE_INFO_DIAGNOSTIC_HINT,
                         escape_kakoune_markup(title),
                         FACE_INFO_DEFAULT,
@@ -144,57 +206,67 @@ pub fn editor_hover(
         }
     };
 
-    let (is_markdown, mut contents) = match result {
-        None => (false, "".to_string()),
-        Some(result) => match result.contents {
-            HoverContents::Scalar(contents) => (true, marked_string_to_hover(contents)),
-            HoverContents::Array(contents) => (
-                true,
-                contents
-                    .into_iter()
-                    .map(marked_string_to_hover)
-                    .filter(|markup| !markup.is_empty())
-                    .join(&if for_hover_buffer {
-                        "\n---\n".to_string()
-                    } else {
-                        format!("\n{{{}}}---{{{}}}\n", FACE_INFO_RULE, FACE_INFO_DEFAULT)
-                    }),
-            ),
-            HoverContents::Markup(contents) => match contents.kind {
-                MarkupKind::Markdown => (
-                    true,
-                    if for_hover_buffer {
-                        contents.value
-                    } else {
-                        markdown_to_kakoune_markup(contents.value)
+    let info: Vec<_> = results
+        .into_iter()
+        .map(|(_, hover)| {
+            let (is_markdown, mut contents) = match hover {
+                None => (false, "".to_string()),
+                Some(hover) => match hover.contents {
+                    HoverContents::Scalar(contents) => (true, marked_string_to_hover(contents)),
+                    HoverContents::Array(contents) => (
+                        true,
+                        contents
+                            .into_iter()
+                            .map(marked_string_to_hover)
+                            .filter(|markup| !markup.is_empty())
+                            .join(&if for_hover_buffer {
+                                "\n---\n".to_string()
+                            } else {
+                                format!("\n{{{}}}---{{{}}}\n", FACE_INFO_RULE, FACE_INFO_DEFAULT)
+                            }),
+                    ),
+                    HoverContents::Markup(contents) => match contents.kind {
+                        MarkupKind::Markdown => (
+                            true,
+                            if for_hover_buffer {
+                                contents.value
+                            } else {
+                                markdown_to_kakoune_markup(contents.value)
+                            },
+                        ),
+                        MarkupKind::PlainText => (false, contents.value),
                     },
-                ),
-                MarkupKind::PlainText => (false, contents.value),
-            },
-        },
-    };
+                },
+            };
 
-    if !for_hover_buffer && contents.contains('\t') {
-        // TODO also expand tabs in the middle.
-        contents = contents
-            .split('\n')
-            .map(|line| {
-                let n = line.bytes().take_while(|c| *c == b'\t').count();
-                " ".repeat(tabstop * n) + &line[n..]
-            })
-            .join("\n");
-    }
+            if !for_hover_buffer && contents.contains('\t') {
+                // TODO also expand tabs in the middle.
+                contents = contents
+                    .split('\n')
+                    .map(|line| {
+                        let n = line.bytes().take_while(|c| *c == b'\t').count();
+                        " ".repeat(tabstop * n) + &line[n..]
+                    })
+                    .join("\n");
+            }
+
+            (is_markdown, contents)
+        })
+        .filter(|(_, contents)| !contents.is_empty())
+        .collect();
 
     match hover_type {
         HoverType::InfoBox => {
-            if contents.is_empty() && diagnostics.is_empty() && code_lenses.is_empty() {
+            if info.is_empty() && diagnostics.is_empty() && code_lenses.is_empty() {
                 return;
             }
 
             let command = format!(
                 "lsp-show-hover {} %§{}§ %§{}§ %§{}§",
                 cursor,
-                contents.replace('§', "§§"),
+                info.iter()
+                    .map(|(_, contents)| contents.replace('§', "§§"))
+                    .join("\n---\n"),
                 diagnostics.replace('§', "§§"),
                 code_lenses.replace('§', "§§"),
             );
@@ -204,14 +276,21 @@ pub fn editor_hover(
             modal_heading,
             do_after,
         } => {
-            show_hover_modal(meta, ctx, modal_heading, do_after, contents, diagnostics);
+            show_hover_modal(
+                meta,
+                ctx,
+                modal_heading,
+                do_after,
+                info.into_iter().map(|(_, contents)| contents).collect(),
+                diagnostics,
+            );
         }
         HoverType::HoverBuffer { client } => {
-            if contents.is_empty() && diagnostics.is_empty() {
+            if info.is_empty() && diagnostics.is_empty() {
                 return;
             }
 
-            show_hover_in_hover_client(meta, ctx, client, is_markdown, contents, diagnostics);
+            show_hover_in_hover_client(meta, ctx, client, info, diagnostics);
         }
     };
 }
@@ -221,13 +300,17 @@ fn show_hover_modal(
     ctx: &Context,
     modal_heading: String,
     do_after: String,
-    contents: String,
+    contents: Vec<String>,
     diagnostics: String,
 ) {
-    let contents = format!("{}\n---\n{}", modal_heading, contents);
+    let contents = contents
+        .into_iter()
+        .map(|contents| format!("{}\n---\n{}", modal_heading, contents))
+        .map(|s| s.replace('§', "§§"))
+        .join("\n---\n");
     let command = format!(
         "lsp-show-hover modal %§{}§ %§{}§ ''",
-        contents.replace('§', "§§"),
+        contents,
         diagnostics.replace('§', "§§"),
     );
     let command = formatdoc!(
@@ -245,10 +328,15 @@ fn show_hover_in_hover_client(
     meta: EditorMeta,
     ctx: &Context,
     hover_client: String,
-    is_markdown: bool,
-    contents: String,
+    contents: Vec<(bool, String)>,
     diagnostics: String,
 ) {
+    // NOTE: Should any containing markdown be enough to use markdown?
+    let is_markdown = contents.iter().any(|(is_markdown, _)| *is_markdown);
+    let contents = contents
+        .into_iter()
+        .map(|(_, content)| content)
+        .join("\n---\n");
     let contents = if diagnostics.is_empty() {
         contents
     } else {

--- a/src/language_features/inlay_hints.rs
+++ b/src/language_features/inlay_hints.rs
@@ -8,10 +8,10 @@ use serde::Deserialize;
 
 use crate::{
     capabilities::{attempt_server_capability, CAPABILITY_INLAY_HINTS},
-    context::Context,
+    context::{Context, RequestParams},
     markup::escape_kakoune_markup,
     position::lsp_position_to_kakoune,
-    types::{EditorMeta, EditorParams},
+    types::{EditorMeta, EditorParams, ServerName},
     util::{editor_quote, escape_tuple_element},
 };
 
@@ -21,24 +21,56 @@ struct InlayHintsOptions {
 }
 
 pub fn inlay_hints(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    if meta.fifo.is_none() && !attempt_server_capability(ctx, &meta, CAPABILITY_INLAY_HINTS) {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|srv| attempt_server_capability(*srv, &meta, CAPABILITY_INLAY_HINTS))
+        .collect();
+    if meta.fifo.is_none() && eligible_servers.is_empty() {
         return;
     }
 
     let params = InlayHintsOptions::deserialize(params).unwrap();
-    let req_params = InlayHintParams {
-        work_done_progress_params: Default::default(),
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = eligible_servers
+        .into_iter()
+        .map(|(server_name, _)| {
+            (
+                server_name.clone(),
+                vec![InlayHintParams {
+                    work_done_progress_params: Default::default(),
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                    },
+                    range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<InlayHintRequest, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx, meta, results| {
+            let results = results
+                .into_iter()
+                .flat_map(|(server_name, v)| {
+                    let v: Vec<_> = v
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|v| (server_name.clone(), v))
+                        .collect();
+                    v
+                })
+                .collect();
+            inlay_hints_response(meta, results, ctx)
         },
-        range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
-    };
-    ctx.call::<InlayHintRequest, _>(meta, req_params, move |ctx, meta, response| {
-        inlay_hints_response(meta, response.unwrap_or_default(), ctx)
-    });
+    );
 }
 
-pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: &mut Context) {
+pub fn inlay_hints_response(
+    meta: EditorMeta,
+    inlay_hints: Vec<(ServerName, InlayHint)>,
+    ctx: &mut Context,
+) {
     let document = match ctx.documents.get(&meta.buffile) {
         Some(document) => document,
         None => return,
@@ -46,15 +78,19 @@ pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: 
     let ranges = inlay_hints
         .into_iter()
         .map(
-            |InlayHint {
-                 position,
-                 label,
-                 padding_left,
-                 padding_right,
-                 ..
-             }| {
+            |(
+                server_name,
+                InlayHint {
+                    position,
+                    label,
+                    padding_left,
+                    padding_right,
+                    ..
+                },
+            )| {
+                let server = &ctx.language_servers[&server_name];
                 let position =
-                    lsp_position_to_kakoune(&position, &document.text, ctx.offset_encoding);
+                    lsp_position_to_kakoune(&position, &document.text, server.offset_encoding);
                 let label = match label {
                     InlayHintLabel::String(s) => s,
                     InlayHintLabel::LabelParts(parts) => {

--- a/src/language_features/range_formatting.rs
+++ b/src/language_features/range_formatting.rs
@@ -1,54 +1,101 @@
+use std::collections::HashMap;
+
 use crate::capabilities::{attempt_server_capability, CAPABILITY_RANGE_FORMATTING};
 use crate::context::*;
 use crate::text_edit::{apply_text_edits_to_buffer, TextEditish};
 use crate::types::*;
+use crate::util::editor_quote;
+use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
 use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_range_formatting(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    if meta.fifo.is_none() && !attempt_server_capability(ctx, &meta, CAPABILITY_RANGE_FORMATTING) {
+    let eligible_servers: Vec<_> = ctx
+        .language_servers
+        .iter()
+        .filter(|server| attempt_server_capability(*server, &meta, CAPABILITY_RANGE_FORMATTING))
+        .filter(|(server_name, _)| {
+            if let Some(fmt_server) = &meta.server {
+                *server_name == fmt_server
+            } else {
+                true
+            }
+        })
+        .collect();
+    if meta.fifo.is_none() && eligible_servers.is_empty() {
+        return;
+    }
+
+    // Ask user to pick which server to use for formatting when multiple options are available.
+    if eligible_servers.len() > 1 {
+        let choices = eligible_servers
+            .into_iter()
+            .map(|(server_name, _)| {
+                let cmd = if meta.fifo.is_some() {
+                    "lsp-range-formatting-sync"
+                } else {
+                    "lsp-range-formatting"
+                };
+                let cmd = format!("{} {}", cmd, server_name);
+                format!("{} {}", editor_quote(server_name), editor_quote(&cmd))
+            })
+            .join(" ");
+        ctx.exec(meta, format!("lsp-menu {}", choices));
         return;
     }
 
     let params = RangeFormattingParams::deserialize(params)
         .expect("Params should follow RangeFormattingParams structure");
 
-    let req_params = params
-        .ranges
-        .iter()
-        .map(|range| DocumentRangeFormattingParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            range: *range,
-            options: params.formatting_options.clone(),
-            work_done_progress_params: Default::default(),
-        })
-        .collect();
-    ctx.batch_call::<RangeFormatting, _>(
+    let (server_name, _) = eligible_servers[0];
+    let mut req_params = HashMap::new();
+    req_params.insert(
+        server_name.clone(),
+        params
+            .ranges
+            .iter()
+            .map(|range| DocumentRangeFormattingParams {
+                text_document: TextDocumentIdentifier {
+                    uri: Url::from_file_path(&meta.buffile).unwrap(),
+                },
+                range: *range,
+                options: params.formatting_options.clone(),
+                work_done_progress_params: Default::default(),
+            })
+            .collect(),
+    );
+
+    let server_name = server_name.clone();
+    ctx.call::<RangeFormatting, _>(
         meta,
-        req_params,
-        move |ctx: &mut Context, meta: EditorMeta, results: Vec<Option<Vec<TextEdit>>>| {
-            let text_edits = results.into_iter().flatten().flatten().collect::<Vec<_>>();
-            editor_range_formatting(meta, text_edits, ctx)
+        RequestParams::Each(req_params),
+        move |ctx, meta, results| {
+            let text_edits = results
+                .into_iter()
+                .filter_map(|(_, v)| v)
+                .flatten()
+                .collect::<Vec<_>>();
+            editor_range_formatting(meta, (server_name, text_edits), ctx)
         },
     );
 }
 
 pub fn editor_range_formatting<T: TextEditish<T>>(
     meta: EditorMeta,
-    text_edits: Vec<T>,
+    result: (ServerName, Vec<T>),
     ctx: &mut Context,
 ) {
+    let (server_name, text_edits) = result;
+    let server = &ctx.language_servers[&server_name];
     let cmd = ctx.documents.get(&meta.buffile).and_then(|document| {
         apply_text_edits_to_buffer(
             &meta.client,
             None,
             text_edits,
             &document.text,
-            ctx.offset_encoding,
+            server.offset_encoding,
             false,
         )
     });

--- a/src/language_features/rename.rs
+++ b/src/language_features/rename.rs
@@ -11,26 +11,54 @@ use super::super::workspace;
 
 pub fn text_document_rename(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = TextDocumentRenameParams::deserialize(params).unwrap();
-    let req_params = RenameParams {
-        text_document_position: TextDocumentPositionParams {
-            text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
-            },
-            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+    let req_params = ctx
+        .language_servers
+        .iter()
+        .map(|(server_name, server_settings)| {
+            (
+                server_name.clone(),
+                vec![RenameParams {
+                    text_document_position: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        },
+                        position: get_lsp_position(
+                            server_settings,
+                            &meta.buffile,
+                            &params.position,
+                            ctx,
+                        )
+                        .unwrap(),
+                    },
+                    new_name: params.new_name.clone(),
+                    work_done_progress_params: Default::default(),
+                }],
+            )
+        })
+        .collect();
+    ctx.call::<Rename, _>(
+        meta,
+        RequestParams::Each(req_params),
+        move |ctx: &mut Context, meta, results| {
+            let result = match results.into_iter().find(|(_, v)| v.is_some()) {
+                Some(result) => result,
+                None => {
+                    let entry = ctx.language_servers.first_entry().unwrap();
+                    (entry.key().clone(), None)
+                }
+            };
+
+            editor_rename(meta, result, ctx)
         },
-        new_name: params.new_name,
-        work_done_progress_params: Default::default(),
-    };
-    ctx.call::<Rename, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
-        editor_rename(meta, result, ctx)
-    });
+    );
 }
 
 // TODO handle version, so change is not applied if buffer is modified (and need to show a warning)
-fn editor_rename(meta: EditorMeta, result: Option<WorkspaceEdit>, ctx: &mut Context) {
+fn editor_rename(meta: EditorMeta, result: (ServerName, Option<WorkspaceEdit>), ctx: &mut Context) {
+    let (server_name, result) = result;
     if result.is_none() {
         return;
     }
     let result = result.unwrap();
-    workspace::apply_edit(meta, result, ctx);
+    workspace::apply_edit(&server_name, meta, result, ctx);
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -16,7 +16,10 @@ use std::time::{self, Duration};
 
 pub fn work_done_progress_cancel(_meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = WorkDoneProgressCancelParams::deserialize(params).expect("Failed to parse params");
-    ctx.notify::<WorkDoneProgressCancel>(params);
+    let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+    for server_name in &servers {
+        ctx.notify::<WorkDoneProgressCancel>(server_name, params.clone());
+    }
 }
 
 pub fn work_done_progress_create(

--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
 
-pub fn find_project_root(language: &str, markers: &[String], path: &str) -> String {
+pub fn find_project_root(server_name: &str, markers: &[String], path: &str) -> String {
     if let Ok(force_root) = env::var("KAK_LSP_FORCE_PROJECT_ROOT") {
         debug!(
             "Using $KAK_LSP_FORCE_PROJECT_ROOT as project root: \"{}\"",
@@ -11,7 +11,7 @@ pub fn find_project_root(language: &str, markers: &[String], path: &str) -> Stri
         );
         return force_root;
     }
-    let vars = gather_env_roots(language);
+    let vars = gather_env_roots(server_name);
     if vars.is_empty() {
         roots_by_marker(markers, path)
     } else {

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,7 +17,7 @@ struct ControllerHandle {
     worker: Worker<EditorRequest, Void>,
 }
 
-type Controllers = HashMap<Route, ControllerHandle>;
+type Controllers = HashMap<Vec<Route>, ControllerHandle>;
 
 /// Start the main event loop.
 ///
@@ -36,7 +36,7 @@ pub fn start(config: &Config, initial_request: Option<String>) -> i32 {
     }
     let editor = editor.unwrap();
 
-    let languages = config.language.clone();
+    let languages = config.language_server.clone();
     let filetypes = filetype_to_language_id_map(config);
 
     let mut controllers: Controllers = HashMap::default();
@@ -88,8 +88,8 @@ pub fn start(config: &Config, initial_request: Option<String>) -> i32 {
                     continue 'event_loop;
                 }
 
-                let language_id = filetypes.get(&request.meta.filetype);
-                if language_id.is_none() {
+                let cfg = filetypes.get(&request.meta.filetype);
+                if cfg.is_none() {
                     let msg = format!(
                         "Language server is not configured for filetype `{}`",
                         &request.meta.filetype
@@ -99,19 +99,26 @@ pub fn start(config: &Config, initial_request: Option<String>) -> i32 {
 
                     continue 'event_loop;
                 }
-                let language_id = language_id.unwrap();
 
-                let root_path = find_project_root(language_id, &languages[language_id].roots, &request.meta.buffile);
-                let route = Route {
-                    session: request.meta.session.clone(),
-                    language: language_id.clone(),
-                    root: root_path.clone(),
-                };
+                let (language_id, servers) = cfg.unwrap();
+                let routes: Vec<_> = servers
+                    .iter()
+                    .map(|server_name| {
+                        let language  = &languages[server_name];
+                        let root = find_project_root(server_name, &language.roots, &request.meta.buffile);
+                        let route = Route {
+                            session: request.meta.session.clone(),
+                            server_name: server_name.clone(),
+                            root,
+                        };
 
-                debug!("Routing editor request to {:?}", route);
+                        debug!("Routing editor request to {:?}", route);
+                        route
+                    })
+                    .collect();
 
                 use std::collections::hash_map::Entry;
-                match controllers.entry(route.clone()) {
+                match controllers.entry(routes.clone()) {
                     Entry::Occupied(controller_entry) => {
                         if let Err(err) = controller_entry.get().worker.sender().send(request.clone())  {
                             error!("Failed to send message to controller: {}", err);
@@ -130,10 +137,11 @@ pub fn start(config: &Config, initial_request: Option<String>) -> i32 {
                         // get didClose message without running controller, unless it crashed
                         // before. In that case didClose can be safely ignored as well.
                         if request.method != notification::DidCloseTextDocument::METHOD {
-                            debug!("Spawning a new controller for {:?}", route);
+                            debug!("Spawning a new controller for {:#?}", routes);
                             controller_entry.insert(spawn_controller(
                                 config.clone(),
-                                route,
+                                language_id.clone(),
+                                routes,
                                 request,
                                 editor.to_editor.sender().clone(),
                             ));
@@ -211,9 +219,18 @@ fn exit_editor_session(controllers: &mut Controllers, request: &EditorRequest) {
         "Editor session `{}` closed, shutting down associated language servers",
         request.meta.session
     );
-    controllers.retain(|route, controller| {
-        if route.session == request.meta.session {
-            info!("Exit {} in project {}", route.language, route.root);
+    controllers.retain(|routes, controller| {
+        let all_from_session = routes
+            .iter()
+            .all(|route| route.session == request.meta.session);
+        let any_from_session = routes
+            .iter()
+            .all(|route| route.session == request.meta.session);
+        assert_eq!(all_from_session, any_from_session);
+        if all_from_session {
+            for route in routes {
+                info!("Exit {} in project {}", route.server_name, route.root);
+            }
             // to notify kak-lsp about editor session end we use the same `exit` notification as
             // used in LSP spec to notify language server to exit, thus we can just clone request
             // and pass it along
@@ -235,17 +252,20 @@ fn stop_session(controllers: &mut Controllers) {
         params: toml::Value::Table(toml::value::Table::default()),
     };
     info!("Shutting down language servers and exiting");
-    for (route, controller) in controllers.drain() {
+    for (routes, controller) in controllers.drain() {
         if controller.worker.sender().send(request.clone()).is_err() {
             error!("Failed to send stop message to language server");
         }
-        info!("Exit {} in project {}", route.language, route.root);
+        for route in &routes {
+            info!("Exit {} in project {}", route.server_name, route.root);
+        }
     }
 }
 
 fn spawn_controller(
     config: Config,
-    route: Route,
+    language_id: LanguageId,
+    routes: Vec<Route>,
     request: EditorRequest,
     to_editor: Sender<EditorResponse>,
 ) -> ControllerHandle {
@@ -253,7 +273,7 @@ fn spawn_controller(
     let channel_capacity = 1024;
 
     let worker = Worker::spawn("Controller", channel_capacity, move |receiver, _| {
-        controller::start(to_editor, receiver, &route, request, config);
+        controller::start(to_editor, receiver, &language_id, &routes, request, config);
     });
 
     ControllerHandle { worker }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,32 +20,44 @@ pub fn request_dynamic_configuration_from_kakoune(
 pub fn request_initialization_options_from_kakoune(
     meta: &EditorMeta,
     ctx: &mut Context,
-) -> Option<Value> {
+) -> Vec<Option<Value>> {
     request_dynamic_configuration_from_kakoune(meta, ctx);
-    let settings = ctx
-        .dynamic_config
-        .language
-        .get(&ctx.language_id)
-        .and_then(|lang| lang.settings.as_ref());
-    let settings = configured_section(ctx, settings);
-    if settings.is_some() {
-        return settings;
-    }
+    let mut sections = Vec::with_capacity(ctx.language_servers.len());
+    let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+    for server_name in &servers {
+        let settings = ctx
+            .dynamic_config
+            .language_server
+            .get(server_name)
+            .and_then(|v| v.settings.as_ref());
+        let settings = configured_section(ctx, server_name, settings);
+        if settings.is_some() {
+            sections.push(settings);
+            continue;
+        }
 
-    let legacy_settings = request_legacy_initialization_options_from_kakoune(meta, ctx);
-    if legacy_settings.is_some() {
-        return legacy_settings;
-    }
+        let legacy_settings = request_legacy_initialization_options_from_kakoune(meta, ctx);
+        if legacy_settings.is_some() {
+            sections.push(legacy_settings);
+            continue;
+        }
 
-    let lang = ctx.config.language.get(&ctx.language_id).unwrap();
-    configured_section(ctx, lang.settings.as_ref())
+        let lang = ctx.config.language_server.get(server_name).unwrap();
+        let settings = configured_section(ctx, server_name, lang.settings.as_ref());
+        sections.push(settings);
+    }
+    sections
 }
 
-pub fn configured_section(ctx: &Context, settings: Option<&Value>) -> Option<Value> {
+pub fn configured_section(
+    ctx: &Context,
+    server_name: &ServerName,
+    settings: Option<&Value>,
+) -> Option<Value> {
     settings.and_then(|settings| {
         ctx.config
-            .language
-            .get(&ctx.language_id)
+            .language_server
+            .get(server_name)
             .and_then(|cfg| cfg.settings_section.as_ref())
             .and_then(|section| settings.get(section).cloned())
     })

--- a/src/text_sync.rs
+++ b/src/text_sync.rs
@@ -19,21 +19,24 @@ use url::Url;
 pub fn text_document_did_open(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = TextDocumentDidOpenParams::deserialize(params)
         .expect("Params should follow TextDocumentDidOpenParams structure");
-    let language_id = ctx.language_id.clone();
+    let document = Document {
+        version: meta.version,
+        text: Rope::from_str(&params.draft),
+    };
+    ctx.documents.insert(meta.buffile.clone(), document);
+
     let params = DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
-            language_id,
+            language_id: ctx.language_id.clone(),
             version: meta.version,
-            text: params.draft,
+            text: params.draft.clone(),
         },
     };
-    let document = Document {
-        version: meta.version,
-        text: Rope::from_str(&params.text_document.text),
-    };
-    ctx.documents.insert(meta.buffile.clone(), document);
-    ctx.notify::<DidOpenTextDocument>(params);
+    let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+    for server_name in &servers {
+        ctx.notify::<DidOpenTextDocument>(server_name, params.clone());
+    }
     text_document_code_lens(meta, ctx);
 }
 
@@ -54,8 +57,11 @@ pub fn text_document_did_change(meta: EditorMeta, params: EditorParams, ctx: &mu
         version,
         text: Rope::from_str(&params.draft),
     };
+
+    // Resets metadata for buffer.
     ctx.documents.insert(meta.buffile.clone(), document);
     ctx.diagnostics.insert(meta.buffile.clone(), Vec::new());
+
     let req_params = DidChangeTextDocumentParams {
         text_document: VersionedTextDocumentIdentifier {
             uri,
@@ -67,7 +73,10 @@ pub fn text_document_did_change(meta: EditorMeta, params: EditorParams, ctx: &mu
             text: params.draft,
         }],
     };
-    ctx.notify::<DidChangeTextDocument>(req_params);
+    let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+    for server_name in &servers {
+        ctx.notify::<DidChangeTextDocument>(server_name, req_params.clone());
+    }
     text_document_code_lens(meta, ctx);
 }
 
@@ -77,35 +86,41 @@ pub fn text_document_did_close(meta: EditorMeta, ctx: &mut Context) {
     let params = DidCloseTextDocumentParams {
         text_document: TextDocumentIdentifier { uri },
     };
-    ctx.notify::<DidCloseTextDocument>(params);
+    let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+    for server_name in &servers {
+        ctx.notify::<DidCloseTextDocument>(server_name, params.clone());
+    }
 }
 
 pub fn text_document_did_save(meta: EditorMeta, ctx: &mut Context) {
-    let text = match ctx.capabilities.as_ref().unwrap().text_document_sync {
-        Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
-            save:
-                Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                    include_text: Some(true),
-                })),
-            ..
-        })) => ctx
-            .documents
-            .get(&meta.buffile)
-            .map(|doc| doc.text.to_string()),
-        _ => None,
-    };
+    let servers: Vec<_> = ctx.language_servers.keys().cloned().collect();
+    for server_name in &servers {
+        let server = &ctx.language_servers[server_name];
+        let text = match server.capabilities.as_ref().unwrap().text_document_sync {
+            Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+                save:
+                    Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                        include_text: Some(true),
+                    })),
+                ..
+            })) => ctx
+                .documents
+                .get(&meta.buffile)
+                .map(|doc| doc.text.to_string()),
+            _ => None,
+        };
 
-    let uri = Url::from_file_path(&meta.buffile).unwrap();
-    let params = DidSaveTextDocumentParams {
-        text_document: TextDocumentIdentifier { uri },
-        text,
-    };
-    ctx.notify::<DidSaveTextDocument>(params);
+        let uri = Url::from_file_path(&meta.buffile).unwrap();
+        let params = DidSaveTextDocumentParams {
+            text_document: TextDocumentIdentifier { uri },
+            text,
+        };
+        ctx.notify::<DidSaveTextDocument>(server_name, params);
+    }
 }
 
 pub fn spawn_file_watcher(
-    root_path: String,
-    watch_requests: HashMap<Option<PathBuf>, Vec<CompiledFileSystemWatcher>>,
+    watch_requests: HashMap<(ServerName, String, Option<PathBuf>), Vec<CompiledFileSystemWatcher>>,
 ) -> Worker<(), Vec<FileEvent>> {
     info!("starting file watcher");
     Worker::spawn(
@@ -113,7 +128,7 @@ pub fn spawn_file_watcher(
         1024, // arbitrary
         move |receiver: Receiver<()>, sender: Sender<Vec<FileEvent>>| {
             let mut watchers = Vec::new();
-            for (path, path_watch_requests) in watch_requests {
+            for ((_, root_path, path), path_watch_requests) in watch_requests {
                 let sender = sender.clone();
                 let callback = move |res: notify::Result<notify::Event>| {
                     match res {
@@ -137,7 +152,7 @@ pub fn spawn_file_watcher(
                 };
                 let path = path.as_deref().unwrap_or_else(|| Path::new(&root_path));
                 if let Err(err) = watcher.watch(path, RecursiveMode::Recursive) {
-                    error!("{}", err);
+                    error!("{:?}: {}", path, err);
                 }
                 watchers.push(watcher);
             }
@@ -192,9 +207,13 @@ fn event_file_changes(
     file_changes
 }
 
-pub fn workspace_did_change_watched_files(changes: Vec<FileEvent>, ctx: &mut Context) {
+pub fn workspace_did_change_watched_files(
+    server_name: &ServerName,
+    changes: Vec<FileEvent>,
+    ctx: &mut Context,
+) {
     let params = DidChangeWatchedFilesParams { changes };
-    ctx.notify::<DidChangeWatchedFiles>(params);
+    ctx.notify::<DidChangeWatchedFiles>(server_name, params);
 }
 
 #[derive(Clone)]
@@ -203,7 +222,11 @@ pub struct CompiledFileSystemWatcher {
     pattern: glob::Pattern,
 }
 
-pub fn register_workspace_did_change_watched_files(options: Option<Value>, ctx: &mut Context) {
+pub fn register_workspace_did_change_watched_files(
+    server_name: &ServerName,
+    options: Option<Value>,
+    ctx: &mut Context,
+) {
     let options = options.unwrap();
     let options = DidChangeWatchedFilesRegistrationOptions::deserialize(options).unwrap();
     assert!(ctx.pending_file_watchers.is_empty());
@@ -247,8 +270,9 @@ pub fn register_workspace_did_change_watched_files(options: Option<Value>, ctx: 
         };
         let default_watch_kind = WatchKind::Create | WatchKind::Change | WatchKind::Delete;
         let kind = watcher.kind.unwrap_or(default_watch_kind);
+        let server = &ctx.language_servers[server_name];
         ctx.pending_file_watchers
-            .entry(root_path)
+            .entry((server_name.clone(), server.root_path.clone(), root_path))
             .or_default()
             .push(CompiledFileSystemWatcher { kind, pattern });
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -81,13 +81,26 @@ pub fn escape_tuple_element(s: &str) -> String {
 }
 
 /// Convert language filetypes configuration into a more lookup-friendly form.
-pub fn filetype_to_language_id_map(config: &Config) -> HashMap<String, String> {
-    let mut filetypes = HashMap::default();
-    for (language_id, language) in &config.language {
-        for filetype in &language.filetypes {
-            filetypes.insert(filetype.clone(), language_id.clone());
+pub fn filetype_to_language_id_map(
+    config: &Config,
+) -> HashMap<String, (LanguageId, Vec<ServerName>)> {
+    let mut filetypes: HashMap<String, (LanguageId, Vec<ServerName>)> = HashMap::default();
+
+    for (server_name, lang_config) in &config.language_server {
+        for filetype in &lang_config.filetypes {
+            let entry = filetypes.entry(filetype.clone()).or_insert((
+                config
+                    .language_ids
+                    .get(filetype)
+                    .cloned()
+                    .unwrap_or_else(|| filetype.clone()),
+                Vec::new(),
+            ));
+            let (_, servers) = entry;
+            servers.push(server_name.clone());
         }
     }
+
     filetypes
 }
 

--- a/test/gopls-dynamic-settings.sh
+++ b/test/gopls-dynamic-settings.sh
@@ -29,7 +29,7 @@ test_tmux capture-pane -p
 
 echo '
 set global lsp_config %{
-	[language.go.settings.gopls]
+	[language_server.gopls.settings.gopls]
 	"formatting.gofumpt" = true
 }' | kak -p "$test_kak_session"
 test_sleep


### PR DESCRIPTION
This PR is my first formal attempt of pushing necessary changes for handling multiple language servers per filetype.

The code is still broken and doesn't compile. I'll keep pushing commits here when I have time to work on this, preferably organized in meaningful commits, in order to track progress and promote discussion over how it is looking.

Also, I'll keep updating this description as new questions arise. Hopefully this PR will serve as a kick-start for solving this long-standing issue (only if desired).

Fixes #17.

To do:
- [x] Make it work properly
- [x] Tidy commits
- [x] Remove labels for single server
- [ ] Sort responses by priority
- [x] Update config file
- [x] Update docs
- [x] Make sure goto buffers are properly set when 2+ servers have different root paths

---

### Configuring multiple language servers

```toml
[language_ids]
javascript = "javascriptreact"
typescript = "typescriptreact"

[language_server.tsserver]
filetypes = ["javascript", "typescript"]
roots = ["package.json", "tsconfig.json", "jsconfig.json", ".git", ".hg"]
command = "typescript-language-server"
args = ["--stdio"]

[language_server.tailwindcss]
filetypes = ["javascript", "typescript"]
roots = ["tailwind.config.js", "tailwind.config.ts"]
command = "tailwindcss-language-server"
args = ["--stdio"]

[language_server.tailwindcss.settings.tailwindcss]
editor = {}
```

> **Note**
> You can now either use `language` or `language_server` as the field name. However, it should be consistent across your config.

## Screenshots

### Capabilities

![image](https://github.com/kak-lsp/kak-lsp/assets/7577128/30493185-627f-4a65-bb95-d1c4bc9b4ec0)

### Formatting (and range formatting)

When there are more than one capable formatting server, a prompt appears so users can choose which formatting server to use (same prompt used in code actions/lenses).

![image](https://github.com/kak-lsp/kak-lsp/assets/7577128/6237c62e-a676-4b9c-83a5-f728b6de91e4)