### PR TITLE
Poor man's LSP: use grep as fallback if LSP for filetype is not available

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -327,6 +327,7 @@ pub fn meta_for_session(session: String, client: Option<String>) -> EditorMeta {
         command_fifo: None,
         write_response_to_fifo: false,
         hook: false,
+        grep_with_error: None,
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -187,7 +187,17 @@ fn handle_broken_editor_request(
 /// This will cancel any blocking requests and also print an error if the
 /// request was not triggered by an editor hook.
 fn return_request_error(to_editor: &Sender<EditorResponse>, request: &EditorRequest, msg: &str) {
-    let command = format!("lsp-show-error {}", editor_quote(msg));
+    let command;
+    if let Some(ref search_word) = request.meta.grep_with_error {
+        command = format!(
+            "lsp-grep-and-show-error {} {}
+        }}",
+            editor_quote(search_word),
+            editor_quote(&format!("{}, trying fallback :grep", msg))
+        );
+    } else {
+        command = format!("lsp-show-error {}", editor_quote(msg));
+    }
 
     // If editor is expecting a fifo response, give it one, so it won't hang.
     if let Some(ref fifo) = request.meta.fifo {

--- a/src/types.rs
+++ b/src/types.rs
@@ -135,6 +135,7 @@ pub struct EditorMeta {
     pub write_response_to_fifo: bool,
     #[serde(default)]
     pub hook: bool,
+    pub grep_with_error: Option<String>,
 }
 
 pub type EditorParams = toml::Value;


### PR DESCRIPTION
Many times you may be editing files for which you have not installed a LSP. If you press `gd` (goto definition) with your cursor on some text, kakoune will give an error with an info message something like:

    "Language server is not configured for filetype `<something>`"

We can do better. As a fallback, run **:grep** on the word found on the cursor _and_ display the error as previously.

---
If you find this feature useful and worthy of inclusion, do feel free to add additional features and build on top of this commit. If there are some important things you still wish for me to fix in this commit, let me know and I'll try to make those changes myself also.

---

BTW I am finding this feature very useful for instance on linker definition files, makefiles, assembly files etc. where I've just not bothered to install some of the various LSPs out there. Please try it out ! :-) 