### PR TITLE
window/showMessageRequest: fix invalid action item serialization

### DIFF
--- a/src/show_message.rs
+++ b/src/show_message.rs
@@ -82,13 +82,14 @@ pub fn show_message_request_next(meta: EditorMeta, ctx: &mut Context) {
     let option_menu_opts = options
         .iter()
         .flat_map(|item| {
-            let mut toml_quoted_item = String::new();
-            item.serialize(toml::ser::ValueSerializer::new(&mut toml_quoted_item))
-                .expect("cannot convert message action to toml");
             let cmd = editor_quote(&format!(
                 "lsp-show-message-request-respond {} {}",
                 request_id,
-                editor_quote(&toml_quoted_item)
+                editor_quote(
+                    toml::to_string(item)
+                        .expect("cannot convert message action to toml")
+                        .as_ref()
+                )
             ));
             [editor_quote(item.title.as_ref()), cmd]
         })


### PR DESCRIPTION
I'm not sure [these lines were needed](https://github.com/kak-lsp/kak-lsp/commit/6ac4d3c585000270d837bfa1941c71218f32ee75#diff-8aa30bdbc7cfcdda8ea817f73e23e7e1257d81c5edcc7e604bb36be6ccc36310R85-R92).
At least it broke the Scala Metals LSP integration for me.
Reverting those lines resolved the issue.

```toml
[package]
name = "kak-lsp-reproduce-toml-bug"
version = "1.0.0"

[dependencies]
lsp-types = { version = "0.95.0", features = ["proposed"] }
serde = "1.0.0"
toml = { version = "0.8.8", features = ["display"] }
```

```rust
use serde::ser::Serialize;
fn main() {
    let item = lsp_types::MessageActionItem {
        title: "some title".to_string(),
        properties: std::collections::HashMap::new(),
    };
    let mut s = String::new();
    item.serialize(toml::ser::ValueSerializer::new(&mut s)).unwrap();
    println!("New style: {:?}", s);
    s = toml::to_string(&item).unwrap();
    println!("Old style: {:?}", s);
}
```

Prints:
```console
New style: "{ title = \"some title\" }"
Old style: "title = \"some title\"\n"
```

The new style was panicking here for some reason:
https://github.com/kak-lsp/kak-lsp/blob/6ac4d3c585000270d837bfa1941c71218f32ee75/src/session.rs#L77.