### PR TITLE
menu: Shift args twice when on-abort is encountered

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -242,6 +242,7 @@ define-command -hidden lsp-menu-impl %{
                         exit;
                     }
                     $on_abort = $args[1];
+                    shift @args;
                 }
                 shift @args;
                 if ($args[0] eq "--") {


### PR DESCRIPTION
Otherwise the `on-abort` action stays in the `@args` :P
