### PR TITLE
Use `flag-lines -after` for inlay diagnostics

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -335,7 +335,7 @@ declare-option -hidden int lsp_completions_timestamp -1
 declare-option -hidden int lsp_completions_selected_item
 declare-option -hidden range-specs lsp_inline_diagnostics
 declare-option -hidden line-specs lsp_diagnostic_lines 0 '0| '
-declare-option -hidden range-specs lsp_inlay_diagnostics
+declare-option -hidden line-specs lsp_inlay_diagnostics
 declare-option -hidden range-specs cquery_semhl
 declare-option -hidden int lsp_timestamp -1
 declare-option -hidden range-specs lsp_references
@@ -2135,9 +2135,9 @@ define-command lsp-diagnostic-lines-disable -params 1 -docstring "lsp-diagnostic
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command lsp-inlay-diagnostics-enable -params 1 -docstring "lsp-inlay-diagnostics-enable <scope>: Enable inlay diagnostics highlighting for <scope>" %{
-    add-highlighter "%arg{1}/lsp_inlay_diagnostics" replace-ranges lsp_inlay_diagnostics
+    add-highlighter "%arg{1}/lsp_inlay_diagnostics" flag-lines -after Default lsp_inlay_diagnostics
 	hook %arg{1} -group lsp-inlay-diagnostics ModeChange (push|pop):.*:insert "remove-highlighter %arg{1}/lsp_inlay_diagnostics"
-	hook %arg{1} -group lsp-inlay-diagnostics ModeChange (push|pop):insert:.* "add-highlighter %arg{1}/lsp_inlay_diagnostics replace-ranges lsp_inlay_diagnostics"
+	hook %arg{1} -group lsp-inlay-diagnostics ModeChange (push|pop):insert:.* "add-highlighter %arg{1}/lsp_inlay_diagnostics flag-lines -after Default lsp_inlay_diagnostics"
 } -shell-script-candidates %{ printf '%s\n' buffer global window }
 
 define-command lsp-inlay-diagnostics-disable -params 1 -docstring "lsp-inlay-diagnostics-disable <scope>: Disable inlay diagnostics highlighting for <scope>"  %{

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -107,19 +107,17 @@ pub fn publish_diagnostics(server_name: &ServerName, params: Params, ctx: &mut C
     // Assemble ranges based on the lines
     let inlay_diagnostics = lines_with_diagnostics
         .iter()
-        .map(|(line_number, (server_name, line_diagnostics))| {
+        .map(|(_, (server_name, line_diagnostics))| {
             let server = &ctx.language_servers[server_name];
-            let line_text = get_line(*line_number as usize, &document.text);
-            let mut pos = lsp_position_to_kakoune(
+            let pos = lsp_position_to_kakoune(
                 &line_diagnostics.range_end,
                 &document.text,
                 server.offset_encoding,
             );
-            pos.column = std::cmp::max(line_text.len_bytes() as u32, 1);
 
             format!(
-                "\"{}+0|%opt[lsp_inlay_diagnostic_gap]{} {{{}}}{}\"",
-                pos,
+                "\"{}|%opt[lsp_inlay_diagnostic_gap]{} {{{}}}{}\"",
+                pos.line,
                 line_diagnostics.symbols,
                 line_diagnostics.text_face,
                 editor_escape_double_quotes(&escape_tuple_element(&escape_kakoune_markup(


### PR DESCRIPTION
Use the new [`flag-lines -after`](https://github.com/mawww/kakoune/commit/c124c8f517c921bee2017cdf5081f3e8b98e27b9) feature to massively improve inlay diagnostics. No longer will they sporadically draw in the middle of a line and no longer will the cursor be affected by them!

**Before:**
![image](https://github.com/kak-lsp/kak-lsp/assets/3515394/7c4ffce5-7577-4e02-95fc-d415fe8bb1ed)

**After:**
![image](https://github.com/kak-lsp/kak-lsp/assets/3515394/1219d77d-e114-480d-aa9e-56b16c83a141)

